### PR TITLE
[UIMA-5753] Get UIMA compile on Java 9 and higher

### DIFF
--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -260,36 +260,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <!-- ************ Java 9 enablement ************** -->
-    <profile>
-      <id>java9</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <dependencies>
-        <!-- 
-          - To avoid having to add the java.xml.bind module in Java 9 and higher, we simply
-          - directly add the correpsonding dependencies. This seems to be the way to go
-          - anyway since java.xml.bind seems to be bound to be removed from future JDKs.
-          - See: https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/43574427
-          -->
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <version>2.3.0</version>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-core</artifactId>
-          <version>2.3.0</version>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <version>2.3.0</version>
-        </dependency>
-      </dependencies>
-    </profile>  
-  </profiles>
 </project>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -260,4 +260,36 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <!-- ************ Java 9 enablement ************** -->
+    <profile>
+      <id>java9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <dependencies>
+        <!-- 
+          - To avoid having to add the java.xml.bind module in Java 9 and higher, we simply
+          - directly add the correpsonding dependencies. This seems to be the way to go
+          - anyway since java.xml.bind seems to be bound to be removed from future JDKs.
+          - See: https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/43574427
+          -->
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+          <version>2.3.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>2.3.0</version>
+        </dependency>
+      </dependencies>
+    </profile>  
+  </profiles>
 </project>

--- a/uimaj-core/src/main/java/org/apache/uima/analysis_engine/annotator/package.html
+++ b/uimaj-core/src/main/java/org/apache/uima/analysis_engine/annotator/package.html
@@ -22,7 +22,7 @@
 <body>
 <p>The Annotator Interfaces, along with supporting interfaces
 and exception classes.</p>
-<p>The annotator interfaces are as follows:</p>
+<p>The annotator interfaces are as follows:
 <ul>
 <li><code>{@link org.apache.uima.analysis_engine.annotator.BaseAnnotator}</code>: the base interface 
     for all annotators.  Annotators should not implement this directly.</li>

--- a/uimaj-core/src/main/java/org/apache/uima/analysis_engine/annotator/package.html
+++ b/uimaj-core/src/main/java/org/apache/uima/analysis_engine/annotator/package.html
@@ -22,7 +22,7 @@
 <body>
 <p>The Annotator Interfaces, along with supporting interfaces
 and exception classes.</p>
-<p>The annotator interfaces are as follows:
+<p>The annotator interfaces are as follows:</p>
 <ul>
 <li><code>{@link org.apache.uima.analysis_engine.annotator.BaseAnnotator}</code>: the base interface 
     for all annotators.  Annotators should not implement this directly.</li>
@@ -34,7 +34,5 @@ and exception classes.</p>
     <code>TextAnnotator</code>, but uses the Java-object-based {@link org.apache.uima.jcas.JCas}
     interface instead of the standard {@link org.apache.uima.cas.CAS} interface. </li>
 </ul>
-</p>
-
 </body>
 </html>

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/package.html
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/package.html
@@ -30,7 +30,7 @@
   <body>
 <p>Implementation and Low-Level API for the CAS Interfaces.</p>
 <p>Internal APIs. Use these APIs at your own risk. APIs in this package are subject to change without notice, even in minor releases. Use of this package is not supported. If you think you have found a bug in this package, please try to reproduce it with the officially supported APIs before reporting it.</p>
-<hr />
+<hr>
 <h1>Internals documentation</h1>
 <p>NOTE: This documentation is plain HTML, generated from a WYSIWIG editor "tinymce".&nbsp;&nbsp; The way to work on this:&nbsp; after setting up a small web page with the tinymce (running from a local file), use the Tools - source code to cut/paste between this file's source and that editor.</p>
 <h2>Java Cover Objects</h2>
@@ -96,7 +96,7 @@
 <p><strong>SnapshotPointerIterator</strong> is a variant which creates a snapshot when the iterator is created, and then (ignoring any subsequent index updates) iterates over that.&nbsp; This iterator won't throw <strong><code>ConcurrentModificationException</code></strong>.</p>
 <p>The basic impls of IntIterator4bag/set/sorted are created by calls to pointerIterator; this method is implemented in each of the IntIterator4bag/set/sorted classes.</p>
 <p>The 2nd argument passed is a ref to this FSIndexRepositoryImpl's int[] used to detect concurrent modification exception.&nbsp; If null is passed, then no testing for this is done.&nbsp; This kind of call happens with the use of the <strong>refIterator()</strong> methods, which are used internally when it is known that the iteration will not be modifying the indexes in any way.</p>
-<hr />
+<hr>
 <p>Iterators which return Java cover object:</p>
 <p>&nbsp;</p>
 <ul>

--- a/uimaj-core/src/main/java/org/apache/uima/pear/tools/package.html
+++ b/uimaj-core/src/main/java/org/apache/uima/pear/tools/package.html
@@ -28,7 +28,7 @@ The <CODE>org.apache.uima.pear.tools</CODE> package provides applications
 and tools that allow installing PEAR packages containing UIMA-compliant 
 components, verifying serviceability of installed components by using 
 UIMA API and browsing PEAR packages.
-<br />
+<br>
 
 </BODY>
 </HTML>

--- a/uimaj-core/src/main/java/org/apache/uima/pear/util/package.html
+++ b/uimaj-core/src/main/java/org/apache/uima/pear/util/package.html
@@ -27,7 +27,7 @@
 The <CODE>org.apache.uima.pear.util</CODE> package provides utilities that 
 facilitate common operations with general files, strings and XML files, 
 as well as simple process message routing and other useful operations.
-<br />
+<br>
 
 </BODY>
 </HTML>

--- a/uimaj-core/src/test/java/org/apache/uima/analysis_engine/impl/AnalysisEngine_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/analysis_engine/impl/AnalysisEngine_implTest.java
@@ -1579,7 +1579,7 @@ public class AnalysisEngine_implTest extends TestCase {
     // Write out descriptor
     File cloneFile = new File(inFile.getParentFile(), "CopyOfAggregateWithManyDelegates.xml");
     BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(cloneFile));
-    XMLSerializer xmlSerializer = new XMLSerializer(true);
+    XMLSerializer xmlSerializer = new XMLSerializer(false);
     xmlSerializer.setOutputStream(os);
     // set the amount to a value which will show up if used
     // indent should not be used because we're using a parser mode which preserves

--- a/uimaj-core/src/test/java/org/apache/uima/util/CasToInlineXmlTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/util/CasToInlineXmlTest.java
@@ -21,10 +21,7 @@ package org.apache.uima.util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import junit.framework.TestCase;
 
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.CAS;
@@ -39,6 +36,9 @@ import org.apache.uima.test.junit_extension.JUnitExtension;
 import org.apache.uima.testTypeSystem_arrays.OfShorts;
 import org.apache.uima.testTypeSystem_arrays.OfStrings;
 import org.custommonkey.xmlunit.XMLAssert;
+import org.custommonkey.xmlunit.XMLUnit;
+
+import junit.framework.TestCase;
 
 
 public class CasToInlineXmlTest extends TestCase {
@@ -149,7 +149,14 @@ public class CasToInlineXmlTest extends TestCase {
         break;
       }
     }
-    XMLAssert.assertXMLEqual(expected, result);
+    boolean whitespaceFlag = XMLUnit.getIgnoreWhitespace();
+    XMLUnit.setIgnoreWhitespace(true);
+    try {
+      XMLAssert.assertXMLEqual(expected, result);
+    }
+    finally {
+      XMLUnit.setIgnoreWhitespace(whitespaceFlag);
+    }
 //    assertEquals(expected, result.trim());
   }
   

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -32,7 +32,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>10</version>
+    <version>11</version>
   </parent>
 
   <groupId>org.apache.uima</groupId>
@@ -193,7 +193,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.0.0</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <javadocVersion>${maven.compiler.source}</javadocVersion> <!-- https://issues.apache.org/jira/browse/UIMA-5369 -->
@@ -212,6 +212,18 @@
               </configuration> 
             </execution>
           </executions>
+          <dependencies>
+            <!-- 
+              - The commons-lang3 3.5 used by default by the Javadoc plugin chokes on the
+              - Java 10 version string. Explicitly updating this plugin dependency works 
+              - around this problem until a new Javadoc plugin version has been released.
+              -->
+            <dependency>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-lang3</artifactId>
+              <version>3.7</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>
@@ -268,35 +280,6 @@
     </plugins>
   </build>
   <profiles>
-    <!-- ************ Java 9 enablement ************** -->
-    <profile>
-      <id>java9</id>
-      <activation>
-        <jdk>9</jdk>
-      </activation>
-      <properties>
-        <maven.surefire.java9>--add-modules java.xml.bind</maven.surefire.java9>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <compilerArgs>
-                  <arg>--add-modules</arg>
-                  <arg>java.xml.bind</arg>
-                </compilerArgs>
-                <target>1.9</target>
-              </configuration>
-            </plugin>
-            
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    
     <profile>
       <id>pmd</id>
       <build>
@@ -449,7 +432,7 @@
           <plugin>              
             <groupId>com.github.siom79.japicmp</groupId>
             <artifactId>japicmp-maven-plugin</artifactId>
-            <version>0.9.4</version>
+            <version>0.11.1</version>
             <configuration>
               <oldVersion>
                 <dependency>
@@ -472,6 +455,28 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
+              </dependency>
+            </dependencies>
           </plugin>
           
           <!-- This copy is to have the api change report included in the source distribution -->

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -507,5 +507,41 @@
         </plugins>
       </build>
     </profile>
+    <!-- ************ Java 9+ enablement ************** -->
+    <profile>
+      <id>java9plus</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <jaxb.version>2.3.0</jaxb.version>
+      </properties>
+      <dependencies>
+        <!-- 
+          - To avoid having to add the java.xml.bind module in Java 9 and higher, we simply
+          - directly add the corresponding dependencies. This seems to be the way to go
+          - anyway since java.xml.bind seems to be bound to be removed from future JDKs.
+          - See: https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/43574427
+          -->
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>${jaxb.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+          <version>${jaxb.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>${jaxb.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>  
   </profiles>
 </project>


### PR DESCRIPTION
Several changes allowing a successful build of UIMA using a Java 9+ JDK.