### PR TITLE
UIMA-5769: Modify the inconsistent method name 'toList'.

### DIFF
--- a/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/FeatureStructureSelection.java
+++ b/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/FeatureStructureSelection.java
@@ -82,7 +82,7 @@ public class FeatureStructureSelection {
    *
    * @return all selected {@link FeatureStructure} objects
    */
-  public List<FeatureStructure> toList() {
+  public List<FeatureStructure> getList() {
     return mFeatureStructures;
   }
 

--- a/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/action/DeleteFeatureStructureAction.java
+++ b/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/action/DeleteFeatureStructureAction.java
@@ -61,6 +61,6 @@ public class DeleteFeatureStructureAction extends BaseSelectionListenerAction {
     FeatureStructureSelection featureStructures =
       new FeatureStructureSelection(getStructuredSelection());
 
-    editor.getDocument().removeFeatureStructures(featureStructures.toList());
+    editor.getDocument().removeFeatureStructures(featureStructures.getList());
   }
 }

--- a/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/editview/EditViewPage.java
+++ b/uimaj-ep-cas-editor/src/main/java/org/apache/uima/caseditor/editor/editview/EditViewPage.java
@@ -769,7 +769,7 @@ final class EditViewPage extends Page implements ISelectionListener {
 
           // filter out selection which are cause by this view itself
           if (editView != part) {
-            viewer.setInput(fsSelection.toList().get(0));
+            viewer.setInput(fsSelection.getList().get(0));
           }
         }
       }


### PR DESCRIPTION
The method is named "toList" that seems like to convert one object to a list, but the method just returns a list of FeatureStructure objects, so that the method name "getList" should be more clear than "toList".