### PR TITLE
[UIMA-5936] PearSpecifier should be able to store every parametertype that analysisEngines support

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/analysis_engine/impl/PearAnalysisEngineWrapper.java
+++ b/uimaj-core/src/main/java/org/apache/uima/analysis_engine/impl/PearAnalysisEngineWrapper.java
@@ -40,7 +40,6 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.impl.ChildUimaContext_impl;
 import org.apache.uima.pear.tools.PackageBrowser;
-import org.apache.uima.resource.Parameter;
 import org.apache.uima.resource.PearSpecifier;
 import org.apache.uima.resource.Resource;
 import org.apache.uima.resource.ResourceConfigurationException;
@@ -50,6 +49,7 @@ import org.apache.uima.resource.ResourceProcessException;
 import org.apache.uima.resource.ResourceSpecifier;
 import org.apache.uima.resource.impl.ResourceManager_impl;
 import org.apache.uima.resource.metadata.ConfigurationParameterSettings;
+import org.apache.uima.resource.metadata.NameValuePair;
 import org.apache.uima.resource.metadata.ProcessingResourceMetaData;
 import org.apache.uima.resource.metadata.ResourceMetaData;
 import org.apache.uima.util.InvalidXMLException;
@@ -267,12 +267,12 @@ public class PearAnalysisEngineWrapper extends AnalysisEngineImplBase {
               .getAnalysisEngineMetaData();
       ConfigurationParameterSettings configurationParameterSettings = analysisEngineMetaData
               .getConfigurationParameterSettings();
-      Parameter[] parameters = pearSpec.getParameters();
+      NameValuePair[] pearParameters = pearSpec.getPearParameters();
 
-      if (parameters != null) {
-        for (Parameter parameter : parameters) {
-          configurationParameterSettings.setParameterValue(parameter.getName(),
-                  parameter.getValue());
+      if (pearParameters != null) {
+        for (NameValuePair pearParameter : pearParameters) {
+          configurationParameterSettings.setParameterValue(pearParameter.getName(),
+        		  pearParameter.getValue());
         }
       }
 

--- a/uimaj-core/src/main/java/org/apache/uima/resource/PearSpecifier.java
+++ b/uimaj-core/src/main/java/org/apache/uima/resource/PearSpecifier.java
@@ -19,6 +19,8 @@
 
 package org.apache.uima.resource;
 
+import org.apache.uima.resource.metadata.NameValuePair;
+
 /**
  * A type of <code>ResourceSpecifier</code> that locate an installed pear <code>Resource</code>.
  * 
@@ -41,18 +43,16 @@ public interface PearSpecifier extends ResourceServiceSpecifier {
   public void setPearPath(String aPearPath);
 
   /**
-   * Gets parameters that may be read by the pear resource class when it is initialized.
+   * Gets pearParameters that may be read by the pear resource class when it is initialized.
    * 
-   * @return an array of parameters.  This will never return <code>null</code>.
+   * @return an array of pearParameters.  This will never return <code>null</code>.
    */
-  public Parameter[] getParameters();
+  public NameValuePair[] getPearParameters();
 
   /**
-   * Sets parameters that may be read by the pear resource class when it is initialized.
+   * Sets pearParameters that may be read by the pear resource class when it is initialized.
    * 
-   * @param parameters the Parameters to set.
+   * @param pearParameters the pearParameters to set.
    */
-  public void setParameters(Parameter[] parameters);
-
-
+  public void setPearParameters(NameValuePair[] pearParameters);
 }

--- a/uimaj-core/src/main/java/org/apache/uima/resource/impl/PearSpecifier_impl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/resource/impl/PearSpecifier_impl.java
@@ -18,9 +18,8 @@
  */
 
 package org.apache.uima.resource.impl;
-
-import org.apache.uima.resource.Parameter;
 import org.apache.uima.resource.PearSpecifier;
+import org.apache.uima.resource.metadata.NameValuePair;
 import org.apache.uima.resource.metadata.impl.MetaDataObject_impl;
 import org.apache.uima.resource.metadata.impl.PropertyXmlInfo;
 import org.apache.uima.resource.metadata.impl.XmlizationInfo;
@@ -37,7 +36,7 @@ public class PearSpecifier_impl extends MetaDataObject_impl implements PearSpeci
   /** PEAR path setting */
   private String mPearPath;
 
-  private Parameter[] mParameters;
+  private NameValuePair[] mParameters;
 
   /**
    * Creates a new <code>PearSpecifier_impl</code>.
@@ -48,7 +47,7 @@ public class PearSpecifier_impl extends MetaDataObject_impl implements PearSpeci
   /**
    * @return Returns the Parameters.
    */
-  public Parameter[] getParameters() {
+  public NameValuePair[] getPearParameters() {
     return this.mParameters;
   }
 
@@ -56,8 +55,8 @@ public class PearSpecifier_impl extends MetaDataObject_impl implements PearSpeci
    * @param parameters
    *          The Parameters to set.
    */
-  public void setParameters(Parameter[] parameters) {
-    this.mParameters = parameters;
+  public void setPearParameters(NameValuePair[] pearParameters) {
+    this.mParameters = pearParameters;
   }
 
   /* (non-Javadoc)
@@ -79,5 +78,5 @@ public class PearSpecifier_impl extends MetaDataObject_impl implements PearSpeci
   }
 
   static final private XmlizationInfo XMLIZATION_INFO = new XmlizationInfo("pearSpecifier",
-          new PropertyXmlInfo[] { new PropertyXmlInfo("pearPath"), new PropertyXmlInfo("parameters") });
+          new PropertyXmlInfo[] { new PropertyXmlInfo("pearPath"), new PropertyXmlInfo("pearParameters") });
 }

--- a/uimaj-core/src/main/resources/resourceSpecifierSchema.xsd
+++ b/uimaj-core/src/main/resources/resourceSpecifierSchema.xsd
@@ -675,15 +675,10 @@
     <complexType>
       <sequence>
         <element name="pearPath" type="string"/>
-        <element name="parameters" minOccurs="0">
+        <element name="pearParameters" minOccurs="0">
           <complexType>
             <sequence>
-              <element name="parameter" minOccurs="0" maxOccurs="unbounded">
-                <complexType>
-                  <attribute name="name" type="string"/>
-                  <attribute name="value" type="string"/>
-                </complexType>
-              </element>
+              <element name="nameValuePair" type="rs:NameValuePairType" minOccurs="0" maxOccurs="unbounded" />
             </sequence>
           </complexType>
         </element>

--- a/uimaj-core/src/test/java/org/apache/uima/analysis_engine/impl/PearAnalysisEngineWrapperTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/analysis_engine/impl/PearAnalysisEngineWrapperTest.java
@@ -25,10 +25,10 @@ import java.util.HashMap;
 import org.apache.uima.pear.tools.PackageBrowser;
 import org.apache.uima.pear.tools.PackageInstaller;
 import org.apache.uima.pear.util.FileUtil;
-import org.apache.uima.resource.Parameter;
 import org.apache.uima.resource.PearSpecifier;
-import org.apache.uima.resource.impl.Parameter_impl;
 import org.apache.uima.resource.impl.PearSpecifier_impl;
+import org.apache.uima.resource.metadata.NameValuePair;
+import org.apache.uima.resource.metadata.impl.NameValuePair_impl;
 import org.apache.uima.test.junit_extension.JUnitExtension;
 import org.junit.Assert;
 
@@ -86,13 +86,13 @@ public class PearAnalysisEngineWrapperTest extends TestCase {
 
   private PearSpecifier createPearSpecifierWithParameters() {
 
-    Parameter parameterStringParam = new Parameter_impl();
-    parameterStringParam.setName(PearAnalysisEngineWrapperTest.PARAMETER_NAME);
-    parameterStringParam.setValue(PearAnalysisEngineWrapperTest.PARAMETER_VALUE_OVERRIDE);
+	NameValuePair pearParameterStringParam = new NameValuePair_impl();
+    pearParameterStringParam.setName(PearAnalysisEngineWrapperTest.PARAMETER_NAME);
+    pearParameterStringParam.setValue(PearAnalysisEngineWrapperTest.PARAMETER_VALUE_OVERRIDE);
 
     PearSpecifier_impl pearSpecifier_impl = new PearSpecifier_impl();
     pearSpecifier_impl.setPearPath(this.installedPearPackage.getRootDirectory().toString());
-    pearSpecifier_impl.setParameters(new Parameter[] { parameterStringParam });
+    pearSpecifier_impl.setPearParameters(new NameValuePair[] { pearParameterStringParam });
     return pearSpecifier_impl;
   }
 

--- a/uimaj-core/src/test/java/org/apache/uima/resource/impl/PearSpecifier_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/impl/PearSpecifier_implTest.java
@@ -29,6 +29,8 @@ import junit.framework.TestCase;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.resource.Parameter;
 import org.apache.uima.resource.PearSpecifier;
+import org.apache.uima.resource.metadata.NameValuePair;
+import org.apache.uima.resource.metadata.impl.NameValuePair_impl;
 import org.apache.uima.test.junit_extension.JUnitExtension;
 import org.apache.uima.util.XMLInputSource;
 
@@ -43,14 +45,14 @@ public class PearSpecifier_implTest extends TestCase {
   public void testProducePearResource() throws Exception {
     PearSpecifier specifier = UIMAFramework.getResourceSpecifierFactory().createPearSpecifier();
     specifier.setPearPath("/home/user/uimaApp/installedPears/testpear");
-    Parameter[] parameters = new Parameter[2];
-    parameters[0] = UIMAFramework.getResourceSpecifierFactory().createParameter();
-    parameters[0].setName("param1");
-    parameters[0].setValue("val1");
-    parameters[1] = UIMAFramework.getResourceSpecifierFactory().createParameter();
-    parameters[1].setName("param2");
-    parameters[1].setValue("val2");
-    specifier.setParameters(parameters);  
+    NameValuePair[] pearParameters = new NameValuePair[2];
+    pearParameters[0] = UIMAFramework.getResourceSpecifierFactory().createNameValuePair();
+    pearParameters[0].setName("param1");
+    pearParameters[0].setValue("val1");
+    pearParameters[1] = UIMAFramework.getResourceSpecifierFactory().createNameValuePair();
+    pearParameters[1].setName("param2");
+    pearParameters[1].setValue("val2");
+    specifier.setPearParameters(pearParameters);  
       
     //compare created specifier with available test specifier
     XMLInputSource in = new XMLInputSource(
@@ -58,18 +60,18 @@ public class PearSpecifier_implTest extends TestCase {
     PearSpecifier pearSpec = UIMAFramework.getXMLParser().parsePearSpecifier(in);
     
     Assert.assertEquals(pearSpec.getPearPath(), specifier.getPearPath());
-    Assert.assertEquals(pearSpec.getParameters()[0].getValue(), specifier.getParameters()[0].getValue());
-    Assert.assertEquals(pearSpec.getParameters()[1].getValue(), specifier.getParameters()[1].getValue());   
+    Assert.assertEquals(pearSpec.getPearParameters()[0].getValue(), specifier.getPearParameters()[0].getValue());
+    Assert.assertEquals(pearSpec.getPearParameters()[1].getValue(), specifier.getPearParameters()[1].getValue());   
     
     //compare created specifier with a manually create pear specifier
     PearSpecifier manPearSpec = new PearSpecifier_impl();
     manPearSpec.setPearPath("/home/user/uimaApp/installedPears/testpear");
-    manPearSpec.setParameters(new Parameter[] { new Parameter_impl("param1", "val1"),
-        new Parameter_impl("param2", "val2") });
+    manPearSpec.setPearParameters(new NameValuePair[] { new NameValuePair_impl("param1", "val1"),
+        new NameValuePair_impl("param2", "val2") });
 
     Assert.assertEquals(manPearSpec.getPearPath(), specifier.getPearPath());
-    Assert.assertEquals(manPearSpec.getParameters()[0].getValue(), specifier.getParameters()[0].getValue());
-    Assert.assertEquals(manPearSpec.getParameters()[1].getValue(), specifier.getParameters()[1].getValue());   
+    Assert.assertEquals(manPearSpec.getPearParameters()[0].getValue(), specifier.getPearParameters()[0].getValue());
+    Assert.assertEquals(manPearSpec.getPearParameters()[1].getValue(), specifier.getPearParameters()[1].getValue());   
 
   }
   
@@ -80,8 +82,8 @@ public class PearSpecifier_implTest extends TestCase {
     try {
       PearSpecifier pearSpec = new PearSpecifier_impl();
       pearSpec.setPearPath("/home/user/uimaApp/installedPears/testpear");
-      pearSpec.setParameters(new Parameter[] { new Parameter_impl("param1", "val1"),
-          new Parameter_impl("param2", "val2") });
+      pearSpec.setPearParameters(new NameValuePair[] { new NameValuePair_impl("param1", "val1"),
+          new NameValuePair_impl("param2", "val2") });
 
       StringWriter sw = new StringWriter();
       pearSpec.toXML(sw);

--- a/uimaj-core/src/test/java/org/apache/uima/util/impl/XMLParser_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/util/impl/XMLParser_implTest.java
@@ -34,6 +34,7 @@ import org.apache.uima.resource.CustomResourceSpecifier;
 import org.apache.uima.resource.Parameter;
 import org.apache.uima.resource.PearSpecifier;
 import org.apache.uima.resource.URISpecifier;
+import org.apache.uima.resource.metadata.NameValuePair;
 import org.apache.uima.test.junit_extension.JUnitExtension;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
@@ -185,12 +186,11 @@ public class XMLParser_implTest extends TestCase {
             JUnitExtension.getFile("XmlParserTest/TestPearSpecifier.xml"));
     PearSpecifier pearSpec = this.mXmlParser.parsePearSpecifier(in);
     assertEquals("/home/user/uimaApp/installedPears/testpear", pearSpec.getPearPath());
-    Parameter[] params = pearSpec.getParameters();
-    assertEquals(2, params.length);
-    assertEquals("param1", params[0].getName());
-    assertEquals("val1", params[0].getValue());
-    assertEquals("param2", params[1].getName());
-    assertEquals("val2", params[1].getValue());  
+    NameValuePair[] pearParams = pearSpec.getPearParameters();
+    assertEquals(2, pearParams.length);
+    assertEquals("param1", pearParams[0].getName());
+    assertEquals("val1", pearParams[0].getValue());
+    assertEquals("param2", pearParams[1].getName());
+    assertEquals("val2", pearParams[1].getValue());  
   }
-
 }

--- a/uimaj-core/src/test/resources/XmlParserTest/TestPearSpecifier.xml
+++ b/uimaj-core/src/test/resources/XmlParserTest/TestPearSpecifier.xml
@@ -18,8 +18,14 @@
  -->
 <pearSpecifier xmlns="http://uima.apache.org/resourceSpecifier">
    <pearPath>/home/user/uimaApp/installedPears/testpear</pearPath>
-   <parameters>
-     <parameter name="param1" value="val1"/>
-     <parameter name="param2" value="val2"/>
-   </parameters>  
+   <pearParameters>
+     <nameValuePair>
+     	<name>param1</name>
+     	<value><string>val1</string></value>
+     </nameValuePair>
+     <nameValuePair>
+     	<name>param2</name>
+     	<value><string>val2</string></value>
+     </nameValuePair>
+   </pearParameters>  
 </pearSpecifier>


### PR DESCRIPTION
- Changed the specifier to store an array of nameValuePairs, so all possible analysisEngine parameters are supported

Jira: https://issues.apache.org/jira/projects/UIMA/issues/UIMA-5936