### PR TITLE
Revert uima 6184

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ checkpoint.dat
 checkpoint.dat.prev
 api-change-report
 .factorypath
-issuesFixed

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -93,6 +93,10 @@
 
     </repository>
     
+    <!--
+      - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
+      - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only
+      - be enabled when really needed.
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
@@ -100,11 +104,15 @@
       <releases>
         <enabled>false</enabled>
       </releases>
-    </repository>    
-    
+    </repository>
+    -->
   </repositories>
   
   <pluginRepositories>
+    <!--
+      - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
+      - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only
+      - be enabled when really needed.
     <pluginRepository>
       <id>apache.snapshots.plugins</id>
       <name>Apache Snapshot Repository - Maven plugins</name>
@@ -119,6 +127,7 @@
         <updatePolicy>never</updatePolicy>        
       </snapshots>
     </pluginRepository>
+    -->
   </pluginRepositories>
   
   <properties>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -32,7 +32,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14-SNAPSHOT</version>
+    <version>13</version>
   </parent>
 
   <groupId>org.apache.uima</groupId>
@@ -90,6 +90,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+
     </repository>
     
     <repository>
@@ -140,8 +141,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.surefire.argLine />
+    <maven.surefire.java9 />
     
-    <japicmp.postAnalysisScript>${project.basedir}/../uimaj-parent/src/main/groovy/api-report.groovy</japicmp.postAnalysisScript>
+    <jacoco.argLine />
+    <java.version>8</java.version>
   </properties>
 
   <dependencyManagement>
@@ -164,4 +168,238 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>@{jacoco.argLine} -Xmx@{maven.surefire.heap} -Xms@{maven.surefire.heap} @{maven.surefire.argLine} @{maven.surefire.java9}</argLine>
+          </configuration>
+        </plugin>
+        
+        <!-- Code quality checking plugins mostly used for CI builds -->
+             
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.6.201602180812</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    
+    <plugins>
+    </plugins>
+  </build>
+ 
+  <profiles>     
+    <profile>
+      <id>pmd</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>cpd</goal>
+                  <goal>pmd</goal>
+                </goals>
+                <configuration>
+                  <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                  <targetJdk>${maven.compiler.target}</targetJdk>
+                  <linkXRef>false</linkXRef>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>findbugs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>findbugs</goal>
+                </goals>
+                <configuration>
+                  <findbugsXmlOutput>true</findbugsXmlOutput>
+                  <xmlOutput>true</xmlOutput>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>cobertura</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>cobertura-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>cobertura</goal>
+                </goals>
+                <configuration>
+                  <formats>
+                    <format>xml</format>
+                  </formats>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <!-- Duplicates on classpath cause an exception in JaCoCo report -->
+                <exclude>**/org/apache/uima/examples/SourceDocumentInformation*</exclude>
+                <exclude>**/org/apache/uima/examples/SourceDocumentInformation_Type*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <propertyName>jacoco.argLine</propertyName>
+                </configuration>
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <rules />
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
+    <!-- **********  Backwards compatibility report generation profile ************** -->
+    <profile>
+      <id>enforce-compatibility</id>
+      <activation>
+        <file>
+          <exists>marker-file-identifying-api-compatibility-check</exists>
+        </file>
+      </activation>
+      <build>
+        
+        <pluginManagement>
+          <plugins>
+            <plugin>
+	            <groupId>org.apache.rat</groupId>
+		          <artifactId>apache-rat-plugin</artifactId>
+		          <executions>
+		            <execution>
+		              <id>default-cli</id>
+		              <configuration>
+		                <excludes combine.children="append">
+	                    <exclude>**/api-change-report/**/*.*</exclude>
+		                </excludes>
+		              </configuration>
+		            </execution>
+	          </executions>
+	          </plugin>
+          </plugins>
+        </pluginManagement> 
+        
+        <plugins>
+          <!-- https://siom79.github.io/japicmp/MavenPlugin.html -->
+          <plugin>              
+            <groupId>com.github.siom79.japicmp</groupId>
+            <artifactId>japicmp-maven-plugin</artifactId>
+            <version>0.13.0</version>
+            <configuration>
+              <oldVersion>
+                <dependency>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${api_check_oldVersion}</version>
+                </dependency>
+              </oldVersion>
+              <parameter>
+                <onlyModified>true</onlyModified>
+                <!-- filter out classes with impl in their package or class name -->
+                <postAnalysisScript>${project.basedir}/../uimaj-parent/src/main/groovy/api-report.groovy</postAnalysisScript>                  
+              </parameter>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>cmp</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          
+          <!-- This copy is to have the api change report included in the source distribution -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-API-change-report</id>
+                <phase>install</phase>  <!-- must follow verify -->
+                <goals><goal>run</goal></goals>
+                <configuration>
+                  <target>
+                    <taskdef name="if" classname="net.sf.antcontrib.logic.IfTask" />
+                    <if>
+                      <available file="${project.build.directory}/japicmp/" />
+                      <then>
+                        <copy toDir="${basedir}/api-change-report">
+                          <fileset dir="${project.build.directory}/japicmp" />
+                        </copy>
+                      </then>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+            
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Reverts changes made towards upgrading UIMAJ Core to the UIMA Parent POM 14 (unreleased as of yet).

The changes will be re-added in a separate branch to be merged after the parent POM 14 has actually been released. This avoids having a SNAPSHOT dependency in UIMAJ Core master.