### PR TITLE
[UIMA-6168] protect indexes fails when there were no indexed fs that needed protecting

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -5406,9 +5406,13 @@ public Iterator<CAS> getViewIterator(String localViewNamePrefix) {
     return r;
   }
   
-//  void dropProtectIndexesLevel () {
-//    svd.fssTobeAddedback.remove(svd.fssTobeAddedback.size() -1);
-//  }
+  void dropProtectIndexesLevel () {
+    if (svd.fssTobeAddedback.isEmpty()) {
+      return;
+    }
+    
+    svd.fssTobeAddedback.remove(svd.fssTobeAddedback.size() -1);
+  }
   
   /**
    * This design is to support normal operations where the

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSsTobeAddedback.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSsTobeAddedback.java
@@ -48,7 +48,10 @@ abstract class FSsTobeAddedback implements AutoCloseable {
   /**
    * does an add back if needed 
    */
-  public void close() { addback();}
+  public void close() { 
+  	addback();
+  	((FSsTobeAddedbackMultiple) this).cas.dropProtectIndexesLevel();
+  }
 
   protected void logPart(FSIndexRepository view) {
     System.out.format("%,d tobeReindexed: view: %s", removes.incrementAndGet(), view);
@@ -208,7 +211,7 @@ abstract class FSsTobeAddedback implements AutoCloseable {
         }
       }
       clear();
-      cas.dropProtectIndexesLevel();
+//      cas.dropProtectIndexesLevel();  // all callers of addback do what's needed, don't do it here 6/2020 MIS
     }
     
     @Override

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSsTobeAddedback.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSsTobeAddedback.java
@@ -208,7 +208,7 @@ abstract class FSsTobeAddedback implements AutoCloseable {
         }
       }
       clear();
-//      cas.dropProtectIndexesLevel();
+      cas.dropProtectIndexesLevel();
     }
     
     @Override

--- a/uimaj-core/src/test/java/org/apache/uima/pear/util/TestPearInstallationVerification.java
+++ b/uimaj-core/src/test/java/org/apache/uima/pear/util/TestPearInstallationVerification.java
@@ -73,7 +73,10 @@ public class TestPearInstallationVerification {
   public void thatSpecialXmlCharactersInTargetPathDoNotBreakInstallation() throws Exception {
     assertThatPearInstalls(
             getFile("pearTests/analysisEngine.pear"),
-            temp.newFolder("<>'\"&"));
+            // on windows, can't use these chars
+            //   <>:"/\|?*  
+            
+            temp.newFolder("!'&"));
   }
 
   private void assertThatPearInstalls(File pearFile, File targetDir) throws InvalidXMLException,


### PR DESCRIPTION
- Restore dropping protection levels in the CAS when closing a FSsTobeAddedback context

@mischor Unfortunately, I can't provide a unit test because I only have a hunch in which situation this happens exactly. The piece of code I encountered problems in is pretty complex and a unit test is not easy to extract. Maybe you have a good idea for constructing a proper unit test once you see this fix.

**Jira link:** https://issues.apache.org/jira/browse/UIMA-6168