### PR TITLE
[UIMA-6245] fixed IndexOutOfBounds exception when expanding types Slot_StrRef and Slot_HeapRef in CVD

### DIFF
--- a/uimaj-tools/src/main/java/org/apache/uima/tools/cvd/FSNode.java
+++ b/uimaj-tools/src/main/java/org/apache/uima/tools/cvd/FSNode.java
@@ -256,12 +256,12 @@ public class FSNode extends FSTreeNode {
         }
       case Slot_StrRef: {
         String[] a = ((StringArray)fs)._getTheArray();
-        makeNodes(arrayNodes, i -> new FSNode(this.fSTreeModel, nc, a[i], 0, i));
+        makeFsArrayNodes(arrayNodes, a, nc);
         break;
         }
       case Slot_HeapRef: {
         TOP[] a = ((FSArray)fs)._getTheArray();
-        makeNodes(arrayNodes, i -> new FSNode(this.fSTreeModel, nc, a[i], 0, i));
+        makeFsArrayNodes(arrayNodes, a, nc);
         break;
         }
       case Slot_BooleanRef: {
@@ -312,6 +312,12 @@ public class FSNode extends FSTreeNode {
         default: Misc.internalError();
         } // end of switch
       }
+    }
+  }
+
+  private <T> void makeFsArrayNodes(List<FSNode> arrayNodes, T[] a, int nodeClass) {
+    for(int idx = 0; idx < a.length; idx++) {
+      arrayNodes.add(new FSNode(this.fSTreeModel, nodeClass, a[idx], 0, idx));
     }
   }
 

--- a/uimaj-tools/src/main/java/org/apache/uima/tools/cvd/FSNode.java
+++ b/uimaj-tools/src/main/java/org/apache/uima/tools/cvd/FSNode.java
@@ -315,6 +315,18 @@ public class FSNode extends FSTreeNode {
     }
   }
 
+  /**
+   * The original makeNodes method (@see org.apache.uima.tools.cvd.MakeNodes) used the size of @arrayNodes to iterate
+   * but @arrayNodes was only initialized and not loaded up with data. This version relies on the size of the actual
+   * data array to copy into the arrayNode to make the iteration loop.
+   *
+   * TODO: This methods is only used for the two datatypes in which makeNodes cause problem (Slot_StrRef/Slot_HeapRef).
+   *       It is possibly that other datatypes could have the same problem.
+   * @param arrayNodes
+   * @param a
+   * @param nodeClass
+   * @param <T>
+   */
   private <T> void makeFsArrayNodes(List<FSNode> arrayNodes, T[] a, int nodeClass) {
     for(int idx = 0; idx < a.length; idx++) {
       arrayNodes.add(new FSNode(this.fSTreeModel, nodeClass, a[idx], 0, idx));


### PR DESCRIPTION
mkNodes function was iterating the loop using the size of the arrayNodes but arrayNodes size was always 0. Using the source array size as limiter to the iterator fixes this problem.