### PR TITLE
Merge UIMA 3.1.1 release branch

### DIFF
--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/PearPackagingMavenPlugin
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/PearPackagingMavenPlugin
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-docbooks
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-docbooks
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-eclipse-plugins
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-eclipse-plugins
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
 
   <properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version> 
+    <version>3.1.1</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +54,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jVinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version> 
+    <version>3.1.2-SNAPSHOT</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +54,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jVinci
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2-SNAPSHOT</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jcasgen-maven-plugin
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.1</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jcasgen-maven-plugin
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -57,7 +57,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -57,7 +57,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
 
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-overview-and-setup
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-overview-and-setup
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-references
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-references
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tools
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tutorials-and-users-guides
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tutorials-and-users-guides
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-v3-users-guide/pom.xml
+++ b/uima-docbook-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-v3-users-guide
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-v3-users-guide/pom.xml
+++ b/uima-docbook-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-v3-users-guide
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-soap
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-soap
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-vinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-vinci
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-bootstrap
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-bootstrap
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-component-test-util
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-component-test-util
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-core
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-core
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-cpe
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-cpe
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-document-annotation
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-document-annotation
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     
@@ -53,7 +53,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-runtime
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     
@@ -53,7 +53,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-runtime
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-tools
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -133,7 +133,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <target>
+              <target combine.self="override">
                 <taskdef classname="net.sf.antcontrib.logic.IfTask" name="if" />
 
                 <condition property="eclipse.home" value="${uima-maven-build-eclipse-home}">

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.1.1</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.1.1</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>
@@ -132,7 +132,7 @@
             <goals>
               <goal>run</goal>
             </goals>
-            <configuration  combine.self="override">
+            <configuration combine.self="override">
               <target>
                 <taskdef classname="net.sf.antcontrib.logic.IfTask" name="if" />
 

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.1.1</version>
+  <version>3.1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.1.1</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>
@@ -132,7 +132,7 @@
             <goals>
               <goal>run</goal>
             </goals>
-            <configuration combine.self="override">
+            <configuration  combine.self="override">
               <target>
                 <taskdef classname="net.sf.antcontrib.logic.IfTask" name="if" />
 

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -132,8 +132,8 @@
             <goals>
               <goal>run</goal>
             </goals>
-            <configuration>
-              <target combine.self="override">
+            <configuration  combine.self="override">
+              <target>
                 <taskdef classname="net.sf.antcontrib.logic.IfTask" name="if" />
 
                 <condition property="eclipse.home" value="${uima-maven-build-eclipse-home}">

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.1.2-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor-ide
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor-ide
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-configurator
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-configurator
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -53,7 +53,7 @@ UIMA data structures to the Eclipse Debug displays</description>
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-debug
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -53,7 +53,7 @@ UIMA data structures to the Eclipse Debug displays</description>
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-debug
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-jcasgen
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-jcasgen
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-launcher
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-launcher
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-pear-packager
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-pear-packager
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-runtime
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-runtime
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-examples
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-examples
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</developerConnection>
     <url>https://github.com/apache/uima-uimaj/tree/master/uimaj-json</url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</developerConnection>
     <url>https://github.com/apache/uima-uimaj/tree/master/uimaj-json</url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.1</version>
+  <version>3.1.2-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the uimaj SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -61,7 +61,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-parent
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- The repositories and pluginRepositories section is duplicated from

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.1.1</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the uimaj SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -61,7 +61,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-parent
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
 
   <!-- The repositories and pluginRepositories section is duplicated from

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jvinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jvinci
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-tools
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-jcas
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.1.1</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-jcas
     </url>
-    <tag>uimaj-3.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>


### PR DESCRIPTION
Merge the branch on which  UIMA Java SDK 3.1.1 was released to update the version in the POMs on the master branch and to incorporate any changes that were done as part of the UIMA Java SDK 3.1.1 release.