### PR TITLE
[UIMA-6267] UIMA SDK Eclipse Plugins fail to build after Eclipse 2020-09 release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   agent any
   tools { 
     maven 'Maven (latest)' 
-    jdk 'JDK 1.8 (latest)' 
+    jdk 'JDK 11 (latest)' 
   }
 
   options {

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -207,15 +207,23 @@
         because only 3.2.0 and 3.2.1 are in 
         repo -->
       <version>[3.9.0,4.0.0)</version>
-			<scope>provided</scope>
+      <scope>provided</scope>
       <exclusions>
-         <exclusion>
-           <groupId>org.eclipse.platform</groupId>
-           <artifactId>org.eclipse.swt</artifactId>
-         </exclusion>
-       </exclusions>
-      
-		</dependency>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt</artifactId>
+        </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
 		<dependency>
       <groupId>org.eclipse.platform</groupId>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -157,7 +157,15 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
-        
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -235,6 +235,15 @@
            <groupId>org.eclipse.platform</groupId>
            <artifactId>org.eclipse.swt</artifactId>
          </exclusion>
+         <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+         <exclusion>
+           <groupId>com.sun.jna</groupId>
+           <artifactId>com.sun.jna</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.sun.jna</groupId>
+           <artifactId>com.sun.jna.platform</artifactId>
+         </exclusion>
        </exclusions>
       
     </dependency>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -209,6 +209,15 @@
            <groupId>org.eclipse.platform</groupId>
            <artifactId>org.eclipse.swt</artifactId>
          </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
        </exclusions>
       
 		</dependency>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -232,15 +232,15 @@
            <groupId>org.eclipse.platform</groupId>
            <artifactId>org.eclipse.swt</artifactId>
          </exclusion>
-        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
-        <exclusion>
-          <groupId>com.sun.jna</groupId>
-          <artifactId>com.sun.jna</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jna</groupId>
-          <artifactId>com.sun.jna.platform</artifactId>
-        </exclusion>
+         <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+         <exclusion>
+           <groupId>com.sun.jna</groupId>
+           <artifactId>com.sun.jna</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>com.sun.jna</groupId>
+           <artifactId>com.sun.jna.platform</artifactId>
+         </exclusion>
        </exclusions>
       
 		</dependency>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -232,6 +232,15 @@
            <groupId>org.eclipse.platform</groupId>
            <artifactId>org.eclipse.swt</artifactId>
          </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
        </exclusions>
       
 		</dependency>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -150,7 +150,15 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
-        
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
      

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -277,19 +277,28 @@
     
      -->
     <dependency>
-       <groupId>org.eclipse.platform</groupId>
-       <artifactId>org.eclipse.ui</artifactId>
-       <version>[3.108.1, 4.0.0)</version>
-       <scope>provided</scope>
-       <exclusions>
-         <exclusion>
-           <groupId>org.eclipse.platform</groupId>
-           <artifactId>org.eclipse.swt</artifactId>
-         </exclusion>
-       </exclusions>
-     </dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.ui</artifactId>
+      <version>[3.108.1, 4.0.0)</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt</artifactId>
+        </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
      
-     <dependency>
+    <dependency>
       <groupId>org.eclipse.swt</groupId>
       <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
       <version>[3.2.0,5.0.0)</version>
@@ -337,7 +346,15 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
-        
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- These next dependencies are just to lock down the

--- a/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/editors/xml/NonRuleBasedDamagerRepairer.java
+++ b/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/editors/xml/NonRuleBasedDamagerRepairer.java
@@ -29,7 +29,7 @@ import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.presentation.IPresentationDamager;
 import org.eclipse.jface.text.presentation.IPresentationRepairer;
-import org.eclipse.jface.util.Assert;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.custom.StyleRange;
 
 public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPresentationRepairer {
@@ -52,7 +52,8 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
   /**
    * @see IPresentationRepairer#setDocument(IDocument)
    */
-  public void setDocument(IDocument document) {
+  @Override
+public void setDocument(IDocument document) {
     fDocument = document;
   }
 
@@ -69,8 +70,9 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
   protected int endOfLineOf(int offset) throws BadLocationException {
 
     IRegion info = fDocument.getLineInformationOfOffset(offset);
-    if (offset <= info.getOffset() + info.getLength())
-      return info.getOffset() + info.getLength();
+    if (offset <= info.getOffset() + info.getLength()) {
+        return info.getOffset() + info.getLength();
+    }
 
     int line = fDocument.getLineOfOffset(offset);
     try {
@@ -84,7 +86,8 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
   /**
    * @see IPresentationDamager#getDamageRegion(ITypedRegion, DocumentEvent, boolean)
    */
-  public IRegion getDamageRegion(ITypedRegion partition, DocumentEvent event,
+  @Override
+public IRegion getDamageRegion(ITypedRegion partition, DocumentEvent event,
           boolean documentPartitioningChanged) {
     if (!documentPartitioningChanged) {
       try {
@@ -98,8 +101,10 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
         if (info.getOffset() <= end && end <= info.getOffset() + info.getLength()) {
           // optimize the case of the same line
           end = info.getOffset() + info.getLength();
-        } else
-          end = endOfLineOf(end);
+        }
+        else {
+            end = endOfLineOf(end);
+        }
 
         end = Math.min(partition.getOffset() + partition.getLength(), end);
         return new Region(start, end - start);
@@ -114,7 +119,8 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
   /**
    * @see IPresentationRepairer#createPresentation(TextPresentation, ITypedRegion)
    */
-  public void createPresentation(TextPresentation presentation, ITypedRegion region) {
+  @Override
+public void createPresentation(TextPresentation presentation, ITypedRegion region) {
     addRange(presentation, region.getOffset(), region.getLength(), fDefaultTextAttribute);
   }
 
@@ -131,8 +137,9 @@ public class NonRuleBasedDamagerRepairer implements IPresentationDamager, IPrese
    *          the attribute describing the style of the range to be styled
    */
   protected void addRange(TextPresentation presentation, int offset, int length, TextAttribute attr) {
-    if (attr != null)
-      presentation.addStyleRange(new StyleRange(offset, length, attr.getForeground(), attr
-              .getBackground(), attr.getStyle()));
+    if (attr != null) {
+        presentation.addStyleRange(new StyleRange(offset, length, attr.getForeground(), attr
+                  .getBackground(), attr.getStyle()));
+    }
   }
 }

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -107,8 +107,16 @@ UIMA data structures to the Eclipse Debug displays</description>
 			<version>[3.8.0, 4.0.0)</version>
 			<scope>provided</scope>
 			
-			<!-- https://issues.apache.org/jira/browse/UIMA-5252 -->
       <exclusions>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-5252 -->
         <exclusion>
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -108,6 +108,7 @@ UIMA data structures to the Eclipse Debug displays</description>
 			<scope>provided</scope>
 			
       <exclusions>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
         <exclusion>
           <groupId>com.sun.jna</groupId>
           <artifactId>com.sun.jna</artifactId>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -177,7 +177,15 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
-        
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
       </exclusions>
 		</dependency>
     

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -104,8 +104,16 @@
 			<artifactId>org.eclipse.jdt.debug.ui</artifactId>
       <version>[3.8.0, 4.0.0)</version>
 			<scope>provided</scope>
-			<!-- https://issues.apache.org/jira/browse/UIMA-5252 -->
       <exclusions>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-5252 -->
         <exclusion>
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -105,6 +105,7 @@
       <version>[3.8.0, 4.0.0)</version>
 			<scope>provided</scope>
       <exclusions>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
         <exclusion>
           <groupId>com.sun.jna</groupId>
           <artifactId>com.sun.jna</artifactId>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -174,6 +174,15 @@
            <groupId>org.eclipse.platform</groupId>
            <artifactId>org.eclipse.swt</artifactId>
          </exclusion>
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
        </exclusions>
        <scope>provided</scope>
      </dependency>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -144,7 +144,15 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.swt</artifactId>
         </exclusion>
-        
+        <!-- https://issues.apache.org/jira/browse/UIMA-6267 -->
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jna</groupId>
+          <artifactId>com.sun.jna.platform</artifactId>
+        </exclusion>
       </exclusions>
 			<scope>provided</scope>
 		</dependency>	


### PR DESCRIPTION
- Add exclusions for the artifacts that are missing