### PR TITLE
[UIMA-6267] UIMA SDK Eclipse Plugins fail to build after Eclipse 2020-09 release

### DIFF
--- a/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
+++ b/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
@@ -50,11 +50,11 @@ under the License.
       <listitem><para>importing the example UIMA code into an Eclipse project. </para>
         </listitem></itemizedlist></para>
   
-  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 3.1 or
+  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 3.3 or
     later.
   </para>
   
-  <note><para>You will need to run Eclipse using a Java at the 1.5 or later level, in order
+  <note><para>You will need to run Eclipse using a Java at the 1.8 or later level, in order
   to use the UIMA Eclipse plugins.</para></note>
   
   <section id="ugr.ovv.eclipse_setup.installation">

--- a/uima-docbook-overview-and-setup/src/docbook/faqs.xml
+++ b/uima-docbook-overview-and-setup/src/docbook/faqs.xml
@@ -382,7 +382,7 @@ under the License.
       </varlistentry>
       <varlistentry id="ugr.faqs.levels_required">
         <term><emphasis role="bold">What Java level and OS are required for the UIMA SDK?</emphasis></term>
-        <listitem><para>As of release 2.6.0, the UIMA SDK requires Java 1.6 or later. Releases from 2.2.1 to
+        <listitem><para>As of release 2.10.4, the UIMA SDK requires Java 1.8. Releases from 2.6.0 to 2.10.3 require Java 1.6 or later. Releases from 2.2.1 to
         2.5.0 require Java 1.5 level (or later).  Releases prior to 2.2.1
           require as a minimum the Java 1.4 level; they will not run on 1.3 (or earlier levels). 
           We routinely test releases with the most modern Javas (e.g. Java 8) as well. 


### PR DESCRIPTION
- Update Java / Eclipse minimum version info in the documentation