### PR TITLE
[UIMA-6269] select.coveredBy with includeAnnotationsWithEndBeyondBounds has broken edge case

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/Subiterator.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/Subiterator.java
@@ -446,6 +446,33 @@ public class Subiterator<T extends AnnotationFS> implements LowLevelIterator<T> 
     
     case coveredBy:
       it.moveToNoReinit(boundingAnnot);
+      
+      if (!isStrict) {
+        // If the bounding annotation evaluates to being "greater" than any of the annotation in the
+        // index according to the index order, then the iterator comes back invalid. 
+        if (!it.isValid()) {
+            it.moveToLastNoReinit();
+        }
+        
+        // In any case, if not doing strict selection, we need to try seeking backwards because we
+        // may have skipped covered annotations which start within the selection range but do not
+        // end within it.
+        boolean wentBack = false;
+        while (it.isValid() && it.getNvc().getBegin() >= boundingAnnot.getBegin()) {
+          it.moveToPreviousNvc();
+          wentBack = true;
+        }
+        
+        if (wentBack) {
+          if (!it.isValid()) {
+            it.moveToFirstNoReinit();
+          }
+          else if (it.getNvc().getBegin() < boundingAnnot.getBegin()) {
+            it.moveToNextNvc();
+          }
+        }
+      }
+      
       //   if an annotation is present (found), position is on it, and if not,
       //   position is at the next annotation that is higher than (or invalid, if there is none)
       //     note that the next found position could be beyond the end.

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -29,9 +29,9 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.uima.UIMAFramework;
-import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
@@ -246,5 +246,57 @@ public class SelectFsTest  {
     assertThat(result)
         .as("Selection (0-1) including start position (0) but not end position (2)")
         .containsExactly(annotation);
+  }
+  
+  @Test
+  public void thatCoveredByWithBeyondEndsCanSelectAnnotationsStartingAtSelectPosition2() {
+    cas.reset();
+    AnnotationFS a1 = cas.createAnnotation(cas.getAnnotationType(), 0, 4);
+    AnnotationFS a2 = cas.createAnnotation(cas.getAnnotationType(), 1, 3);
+    cas.addFsToIndexes(a1);
+    cas.addFsToIndexes(a2);
+
+    List<AnnotationFS> result = cas.select(Annotation.class)
+        .coveredBy(0, 2)
+        .includeAnnotationsWithEndBeyondBounds()
+        .collect(Collectors.toList());
+
+    assertThat(result).containsExactly(a1, a2);
+  }
+
+  @Test
+  public void thatCoveredByWithBeyondEndsCanSelectAnnotationsStartingAtSelectPosition3() {
+    cas.reset();
+    AnnotationFS a1 = cas.createAnnotation(cas.getAnnotationType(), 0, 5);
+    AnnotationFS a2 = cas.createAnnotation(cas.getAnnotationType(), 1, 4);
+    AnnotationFS a3 = cas.createAnnotation(cas.getAnnotationType(), 2, 6);
+    cas.addFsToIndexes(a1);
+    cas.addFsToIndexes(a2);
+    cas.addFsToIndexes(a3);
+
+    List<AnnotationFS> result = cas.select(Annotation.class)
+        .coveredBy(0, 3)
+        .includeAnnotationsWithEndBeyondBounds()
+        .collect(Collectors.toList());
+
+    assertThat(result).containsExactly(a1, a2, a3);
+  }
+
+  @Test
+  public void thatCoveredByWithBeyondEndsCanSelectAnnotationsStartingAtSelectPosition4() {
+    cas.reset();
+    AnnotationFS a1 = cas.createAnnotation(cas.getAnnotationType(), 0, 4);
+    AnnotationFS a2 = cas.createAnnotation(cas.getAnnotationType(), 1, 5);
+    AnnotationFS a3 = cas.createAnnotation(cas.getAnnotationType(), 2, 2);
+    cas.addFsToIndexes(a1);
+    cas.addFsToIndexes(a2);
+    cas.addFsToIndexes(a3);
+
+    List<AnnotationFS> result = cas.select(Annotation.class)
+        .coveredBy(0, 3)
+        .includeAnnotationsWithEndBeyondBounds()
+        .collect(Collectors.toList());
+
+    assertThat(result).containsExactly(a1, a2, a3);
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -19,17 +19,20 @@
 
 package org.apache.uima.cas.impl;
 
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -226,7 +229,22 @@ public class SelectFsTest  {
 
     prec2 = jCas.select(Token.class).between(b, e).backwards().asList();
     assertEquals(Arrays.asList(d, c), prec2);
+  }
+  
+  @Test
+  public void thatCoveredByWithBeyondEndsCanSelectAnnotationsStartingAtSelectPosition() throws Exception
+  {
+    cas.reset();
+    AnnotationFS annotation = cas.createAnnotation(cas.getAnnotationType(), 0, 2);
+    cas.addFsToIndexes(annotation);
 
+    List<AnnotationFS> result = cas.select(Annotation.class)
+        .coveredBy(0, 1)
+        .includeAnnotationsWithEndBeyondBounds()
+        .collect(toList());
 
+    assertThat(result)
+        .as("Selection (0-1) including start position (0) but not end position (2)")
+        .containsExactly(annotation);
   }
 }


### PR DESCRIPTION
- Fixed edge case
- Added unit test
