### PR TITLE
[UIMA-6272] UIMA doesn't build on Java 14

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/internal/util/EncodedPrintStream.java
+++ b/uimaj-core/src/main/java/org/apache/uima/internal/util/EncodedPrintStream.java
@@ -72,7 +72,7 @@ public class EncodedPrintStream extends PrintStream {
     "test".getBytes(encoding);
   }
 
-  private final void writeBytes(byte[] bytes) {
+  public final void writeBytes(byte[] bytes) {
     super.write(bytes, 0, bytes.length);
   }
 


### PR DESCRIPTION
- Make EncodedPrintStream.writeBytes(byte[]) public like the super method

(cherry picked from commit 995b0521b78284771d051e5c8574cf7d46b397fe)