### PR TITLE
[NO JIRA] Fix JavaDoc and exclude .factorypath Eclipse configuration file from rat check

### DIFF
--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/BaseCPMImpl.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/BaseCPMImpl.java
@@ -646,7 +646,7 @@ public class BaseCPMImpl implements BaseCPM, Runnable {
    * This method is called by an application to begin processing given Collection. It creates a new
    * thread, adds it to a ThreadGroup and starts it.
    * 
-   * @see org.apache.uima.collection.base_cpm.BaseCPM#process(org.apache.uima.collection.base_cpm.BaseCollectionReader)
+   * @see org.apache.uima.collection.base_cpm.BaseCPM#process()
    */
   @Override
   public void process() throws ResourceInitializationException {

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -233,6 +233,7 @@
               <id>default-cli</id>
               <configuration>
                 <excludes combine.children="append">
+                  <exclude>.factorypath</exclude>
                   <exclude>src/main/run_configuration/*.launch</exclude>
                 </excludes>    
               </configuration>


### PR DESCRIPTION
Fix JavaDoc and exclude .factorypath Eclipse configuration file from rat check