### PR TITLE
[UIMA-6286] select following finds zero-width annotation at reference end position

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/SelectFSs.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/SelectFSs.java
@@ -390,9 +390,15 @@ public interface SelectFSs<T extends FeatureStructure> extends Iterable<T>, Stre
    * @return the updated SelectFSs object
    */
   SelectFSs<T> following(Annotation annotation);
+  
   /**
-   * For AnnotationIndex, position to first Annotation whose begin &gt;= position;
-   * @param position start following this position
+   * Select {@link Annotation annotations} that follow the specified document
+   * position (i.e. character offset). This is equivalent to performing a 
+   * {@code following(new Annotation(jcas, 0, position)}, so all annotations starting at
+   * {@code position} or after are returned, including zero-width annotations.
+   * 
+   * @param position
+   *          start following this position
    * @return the updated SelectFSs object
    */
   SelectFSs<T> following(int position);
@@ -422,12 +428,15 @@ public interface SelectFSs<T extends FeatureStructure> extends Iterable<T>, Stre
    * @return the updated SelectFSs object
    */
   SelectFSs<T> preceding(Annotation annotation);
+  
   /**
-   * For AnnotationIndex, set up a selection that will go from the beginning to  
-   * the first Annotation to the left of the specified position, 
-   * ending at the last Annotation whose end &lt;= position.
-   * Annotations whose end &gt; position are skipped.
-   * @param position the position to start before.
+   * Select {@link Annotation annotations} that precede the specified document
+   * position (i.e. character offset). This is equivalent to performing a 
+   * {@code preceding(new Annotation(jcas, position, Integer.MAX_VALUE)}, so all annotations 
+   * ending at {@code position} or before are returned, including zero-width annotations.
+   * 
+   * @param position
+   *          start following this position
    * @return the updated SelectFSs object
    */
   SelectFSs<T> preceding(int position);

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -420,6 +420,23 @@ public class SelectFsTest  {
     assertThat(selection)
             .isEmpty();
   }
+
+  @Test
+  public void thatSelectPrecedingDoesNotFindNonZeroWidthAnnotationEndingAtZeroWidthAnnotation()
+  {
+    Annotation a1 = cas.createAnnotation(cas.getAnnotationType(), 20, 20);
+    Annotation a2 = cas.createAnnotation(cas.getAnnotationType(), 10, 20);
+    
+    asList(a1, a2).forEach(cas::addFsToIndexes);
+    
+    List<Annotation> selection = cas.select(Annotation.class)
+        .preceding(a1)
+        .asList();
+    
+    assertThat(selection)
+            .isEmpty();
+  }
+
   @Test
   public void thatSelectFollowingReturnsAdjacentAnnotation()
   {

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -43,11 +43,15 @@ import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.XMLInputSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import x.y.z.Sentence;
 import x.y.z.Token;
 
+// Sorting only to keep the list in Eclipse ordered so it is easier spot if related tests fail
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SelectFsTest  {
 
   private static TypeSystemDescription typeSystemDescription;
@@ -175,7 +179,7 @@ public class SelectFsTest  {
   }
   
   @Test
-  public void testempty() {
+  public void thatIsEmptyWorks() {
     cas.reset();
     JCas jcas = cas.getJCas();
     cas.setDocumentText("t1 t2 t3 t4");
@@ -385,6 +389,37 @@ public class SelectFsTest  {
             .isEmpty();
   }
 
+  @Test
+  public void thatSelectFollowingDoesNotFindZeroWidthAnnotationAtEnd()
+  {
+    Annotation a1 = cas.createAnnotation(cas.getAnnotationType(), 10, 20);
+    Annotation a2 = cas.createAnnotation(cas.getAnnotationType(), 20, 20);
+    
+    asList(a1, a2).forEach(cas::addFsToIndexes);
+    
+    List<Annotation> selection = cas.select(Annotation.class)
+        .following(a1)
+        .asList();
+    
+    assertThat(selection)
+            .isEmpty();
+  }
+
+  @Test
+  public void thatSelectPrecedingDoesNotFindZeroWidthAnnotationAtStart()
+  {
+    Annotation a1 = cas.createAnnotation(cas.getAnnotationType(), 10, 20);
+    Annotation a2 = cas.createAnnotation(cas.getAnnotationType(), 10, 10);
+    
+    asList(a1, a2).forEach(cas::addFsToIndexes);
+    
+    List<Annotation> selection = cas.select(Annotation.class)
+        .preceding(a1)
+        .asList();
+    
+    assertThat(selection)
+            .isEmpty();
+  }
   @Test
   public void thatSelectFollowingReturnsAdjacentAnnotation()
   {


### PR DESCRIPTION
- When selecting following annotations, skip over zero-width annotations that are the the end position of the reference interval
- Added unit test checking behavior for zero-width annotations at start/end of reference when selecting following and preceding