### PR TITLE
[UIMA-6289] SelectFS.coveredBy not selecting annotations with exact same bounds as annotation argument

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/Subiterator.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/Subiterator.java
@@ -456,13 +456,13 @@ public class Subiterator<T extends AnnotationFS> implements LowLevelIterator<T> 
       if (!isUnambiguous && !isUseTypePriority) {
         // If the bounding annotation evaluates to being "greater" than any of the annotation in the
         // index according to the index order, then the iterator comes back invalid. 
-        if (!it.isValid()) {
+        boolean wasValid = it.isValid();
+        if (!wasValid) {
             it.moveToLastNoReinit();
         }
         
-        // In any case, if not doing strict selection, we need to try seeking backwards because we
-        // may have skipped covered annotations which start within the selection range but do not
-        // end within it.
+        // We need to try seeking backwards because we may have skipped covered annotations which
+        // start within the selection range but do not end within it.
         boolean wentBack = false;
         while (it.isValid() && it.getNvc().getBegin() >= boundingAnnot.getBegin()) {
           it.moveToPreviousNvc();
@@ -476,6 +476,11 @@ public class Subiterator<T extends AnnotationFS> implements LowLevelIterator<T> 
           else if (it.getNvc().getBegin() < boundingAnnot.getBegin()) {
             it.moveToNextNvc();
           }
+        }
+        else if (!wasValid) {
+          // No backwards seeking was performed and the iterator was initially invalid, so we 
+          // invalidate it again
+          makeInvalid();
         }
       }
       

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsAssert.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsAssert.java
@@ -96,6 +96,8 @@ public class SelectFsAssert {
       Type type1 = ti.next();
       Type type2 = ti.next();
       
+      long timeExpected = 0;
+      long timeActual = 0;
       for (int i = 0; i < aIterations; i++) {
         if (i % 10 == 0) {
           System.out.print(i);
@@ -107,8 +109,13 @@ public class SelectFsAssert {
         initRandomCas(randomCas, 3 * i, 0, types.values().toArray(new Type[types.size()]));
   
         for (Annotation context : randomCas.<Annotation>select(type1)) {
+          long t1 = System.currentTimeMillis();
           List<AnnotationFS> expected = aExpected.select(randomCas, type2, context);
+          timeExpected += System.currentTimeMillis() - t1;
+          
+          long t2 = System.currentTimeMillis();
           List<AnnotationFS> actual = aActual.select(randomCas, type2, context);
+          timeActual += System.currentTimeMillis() - t2;
   
           assertThat(actual)
               .as("Selected [%s] with context [%s]@[%d..%d]%n%s%n", type2.getShortName(), 
@@ -118,6 +125,7 @@ public class SelectFsAssert {
         }
       }
       System.out.print(aIterations);
+      System.out.printf(" (time 1: %4dms / time 2: %4dms)", timeExpected, timeActual);
     }
     finally {
       System.out.println();

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsCoveredByWithTypePrioritiesTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsCoveredByWithTypePrioritiesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.impl;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.UIMAFramework.getResourceSpecifierFactory;
+import static org.apache.uima.util.CasCreationUtils.createCas;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Type;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.metadata.TypePriorities;
+import org.apache.uima.resource.metadata.TypePriorityList;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Includes several additional tests for {@code coverdBy} selection which require the CAS to be
+ * prepared differently than in the {@link SelectFsTest}, e.g. with type priorities.
+ */
+public class SelectFsCoveredByWithTypePrioritiesTest {
+
+    private static final String TYPE_NAME_SUBTYPE = "uima.test.selectfs.SubType";
+    
+    private static CAS cas;
+    private static Type typeSubType;
+    
+    @BeforeClass
+    public static void setupClass() throws Exception
+    {
+        TypeSystemDescription tsd = getResourceSpecifierFactory().createTypeSystemDescription();
+        tsd.addType(TYPE_NAME_SUBTYPE, "", CAS.TYPE_NAME_ANNOTATION);
+        
+        TypePriorities prios = getResourceSpecifierFactory().createTypePriorities();
+        TypePriorityList typePrioList = prios.addPriorityList();
+        typePrioList.addType(TYPE_NAME_SUBTYPE);
+        typePrioList.addType(CAS.TYPE_NAME_ANNOTATION);
+        
+        cas = createCas(tsd, prios, null, null, null);
+        typeSubType = cas.getTypeSystem().getType(TYPE_NAME_SUBTYPE);
+    }
+    
+    @Before
+    public void setup()
+    {
+        cas.reset();
+    }
+    
+    @Test
+    public void thatCoveredByFindsTypeUsingSubtype() throws Exception {
+       
+        Annotation a1 = (Annotation) cas.createAnnotation(cas.getAnnotationType(), 5, 10);
+        Annotation subType = (Annotation) cas.createAnnotation(typeSubType, 5, 10);
+        
+        asList(a1, subType)
+            .forEach(a -> cas.addFsToIndexes(a));
+
+        assertThat(cas.select(Annotation.class).coveredBy(subType).asList())
+                .containsExactly(a1);
+    }
+    
+    @Test
+    public void thatCoveredByFindsTypeUsingUnindexedSubtype() throws Exception {
+        Annotation a1 = (Annotation) cas.createAnnotation(cas.getAnnotationType(), 5, 10);
+        Annotation subType = (Annotation) cas.createAnnotation(typeSubType, 5, 10);
+        
+        asList(a1)
+            .forEach(a -> cas.addFsToIndexes(a));
+
+        assertThat(cas.select(Annotation.class).coveredBy(subType).asList())
+                .containsExactly(a1);
+    }
+
+    @Test
+    public void thatCoveredByFindsSubtypeUsingType() throws Exception {
+        Annotation a1 = (Annotation) cas.createAnnotation(cas.getAnnotationType(), 5, 10);
+        Annotation subType = (Annotation) cas.createAnnotation(typeSubType, 5, 10);
+        
+        asList(a1, subType)
+                .forEach(a -> cas.addFsToIndexes(a));
+
+        assertThat(cas.select(Annotation.class).coveredBy(a1).asList())
+                .containsExactly(subType);
+    }
+
+    @Test
+    public void thatCoveredByWorksWithOffsets() throws Exception {
+        Annotation a1 = (Annotation) cas.createAnnotation(cas.getAnnotationType(), 5, 10);
+        
+        asList(a1)
+            .forEach(a -> cas.addFsToIndexes(a));
+
+        assertThat(cas.select(Annotation.class).coveredBy(5, 10).asList())
+                .containsExactly(a1);
+    }
+    
+    @Test
+    public void thatCoveredBySkipsIndexedAnchorAnnotation() throws Exception {
+      JCas jCas = cas.getJCas();
+
+      Annotation a1 = new Annotation(jCas, 5, 10);
+      Annotation a2 = new Annotation(jCas, 5, 15);
+      Annotation a3 = new Annotation(jCas, 0, 10);
+      Annotation a4 = new Annotation(jCas, 0, 15);
+      Annotation a5 = new Annotation(jCas, 5, 7);
+      Annotation a6 = new Annotation(jCas, 8, 10);
+      Annotation a7 = new Annotation(jCas, 6, 9);
+      Annotation a8 = new Annotation(jCas, 5, 10);
+      asList(a1, a2, a3, a4, a5, a6, a7, a8).forEach(Annotation::addToIndexes);
+
+      assertThat(jCas.select(Annotation.class).coveredBy(a1).asList())
+          .containsExactly(a8, a5, a7, a6);
+
+      Annotation subType = (Annotation) cas.createAnnotation(typeSubType, 5, 10);
+      subType.addToIndexes();
+
+      assertThat(jCas.select(Annotation.class).coveredBy(subType).asList())
+          .containsExactly(a1, a8, a5, a7, a6);
+    }
+}
+

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -538,14 +538,28 @@ public class SelectFsTest {
   }
   
   @Test
-  public void thatSelectFsBehaviorAlignsWithPrecedingPredicateOnRandomData() throws Exception
+  public void thatCasSelectFsBehaviorAlignsWithPrecedingPredicateOnRandomData() throws Exception
   {
-    System.out.print("Preceding -- ");
+    System.out.print("Preceding (CAS select)   -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> preceding(candidate, context))
             .collect(toList()),
         (cas, type, context) -> cas.<Annotation>select(type)
+            .preceding(context)
+            .map(a -> (AnnotationFS) a)
+            .collect(toList()));
+  }
+
+  @Test
+  public void thatIndexSelectFsBehaviorAlignsWithPrecedingPredicateOnRandomData() throws Exception
+  {
+    System.out.print("Preceding (Index select) -- ");
+    assertSelectionIsEqualOnRandomData(30, 10,
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .filter(candidate -> preceding(candidate, context))
+            .collect(toList()),
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .preceding(context)
             .map(a -> (AnnotationFS) a)
             .collect(toList()));
@@ -567,14 +581,28 @@ public class SelectFsTest {
   }
   
   @Test
-  public void thatSelectFsBehaviorAlignsWithFollowingPredicateOnRandomData() throws Exception
+  public void thatCasSelectFsBehaviorAlignsWithFollowingPredicateOnRandomData() throws Exception
   {
-    System.out.print("Following -- ");
+    System.out.print("Following (CAS select)   -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> following(candidate, context))
             .collect(toList()),
         (cas, type, context) -> cas.<Annotation>select(type)
+            .following(context)
+            .map(a -> (AnnotationFS) a)
+            .collect(toList()));
+  }
+
+  @Test
+  public void thatIndexSelectFsBehaviorAlignsWithFollowingPredicateOnRandomData() throws Exception
+  {
+    System.out.print("Following (Index select) -- ");
+    assertSelectionIsEqualOnRandomData(30, 10,
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .filter(candidate -> following(candidate, context))
+            .collect(toList()),
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .following(context)
             .map(a -> (AnnotationFS) a)
             .collect(toList()));
@@ -597,9 +625,9 @@ public class SelectFsTest {
   }
   
   @Test
-  public void thatSelectFsBehaviorAlignsWithCoveredByPredicateOnRandomData() throws Exception
+  public void thatCasSelectFsBehaviorAlignsWithCoveredByPredicateOnRandomData() throws Exception
   {
-    System.out.print("CoveredBy -- ");
+    System.out.print("CoveredBy (CAS select)   -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> coveredBy(candidate, context))
@@ -610,6 +638,20 @@ public class SelectFsTest {
             .collect(toList()));
   }
 
+  @Test
+  public void thatIndexSelectFsBehaviorAlignsWithCoveredByPredicateOnRandomData() throws Exception
+  {
+    System.out.print("CoveredBy (Index select) -- ");
+    assertSelectionIsEqualOnRandomData(30, 10,
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .filter(candidate -> coveredBy(candidate, context))
+            .collect(toList()),
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .coveredBy(context)
+            .map(a -> (AnnotationFS) a)
+            .collect(toList()));
+  }
+  
   @Test
   public void thatSelectFsBehaviorAlignsWithCoveringPredicate() throws Exception {
     // X covering Y means that Y is covered by Y, so we need to select the covered by annotations
@@ -627,14 +669,28 @@ public class SelectFsTest {
   }
 
   @Test
-  public void thatSelectFsBehaviorAlignsWithCoveringPredicateOnRandomData() throws Exception
+  public void thatCasSelectFsBehaviorAlignsWithCoveringPredicateOnRandomData() throws Exception
   {
-    System.out.print("Covering  -- ");
+    System.out.print("Covering  (CAS select)   -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> covering(candidate, context))
             .collect(toList()),
         (cas, type, context) -> cas.<Annotation>select(type)
+            .covering(context)
+            .map(a -> (AnnotationFS) a)
+            .collect(toList()));
+  }
+  
+  @Test
+  public void thatIndexSelectFsBehaviorAlignsWithCoveringPredicateOnRandomData() throws Exception
+  {
+    System.out.print("Covering  (Index select) -- ");
+    assertSelectionIsEqualOnRandomData(30, 10,
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .filter(candidate -> covering(candidate, context))
+            .collect(toList()),
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .covering(context)
             .map(a -> (AnnotationFS) a)
             .collect(toList()));
@@ -657,14 +713,28 @@ public class SelectFsTest {
   }  
 
   @Test
-  public void thatSelectFsBehaviorAlignsWithColocatedPredicateOnRandomData() throws Exception
+  public void thatCasSelectFsBehaviorAlignsWithColocatedPredicateOnRandomData() throws Exception
   {
-    System.out.print("Colocated -- ");
+    System.out.print("Colocated (CAS select)   -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> colocated(candidate, context))
             .collect(toList()),
         (cas, type, context) -> cas.<Annotation>select(type)
+            .at(context)
+            .map(a -> (AnnotationFS) a)
+            .collect(toList()));
+  }
+
+  @Test
+  public void thatIndexSelectFsBehaviorAlignsWithColocatedPredicateOnRandomData() throws Exception
+  {
+    System.out.print("Colocated (Index select) -- ");
+    assertSelectionIsEqualOnRandomData(30, 10,
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
+            .filter(candidate -> colocated(candidate, context))
+            .collect(toList()),
+        (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .at(context)
             .map(a -> (AnnotationFS) a)
             .collect(toList()));

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -540,6 +540,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithPrecedingPredicateOnRandomData() throws Exception
   {
+    System.out.print("Preceding -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> preceding(candidate, context))
@@ -568,6 +569,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithFollowingPredicateOnRandomData() throws Exception
   {
+    System.out.print("Following -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> following(candidate, context))
@@ -597,6 +599,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithCoveredByPredicateOnRandomData() throws Exception
   {
+    System.out.print("CoveredBy -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> coveredBy(candidate, context))
@@ -626,6 +629,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithCoveringPredicateOnRandomData() throws Exception
   {
+    System.out.print("Covering  -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> covering(candidate, context))
@@ -655,6 +659,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithColocatedPredicateOnRandomData() throws Exception
   {
+    System.out.print("Colocated -- ");
     assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> colocated(candidate, context))

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsTest.java
@@ -540,7 +540,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithPrecedingPredicateOnRandomData() throws Exception
   {
-    assertSelectionIsEqualOnRandomData(
+    assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> preceding(candidate, context))
             .collect(toList()),
@@ -568,7 +568,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithFollowingPredicateOnRandomData() throws Exception
   {
-    assertSelectionIsEqualOnRandomData(
+    assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> following(candidate, context))
             .collect(toList()),
@@ -597,7 +597,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithCoveredByPredicateOnRandomData() throws Exception
   {
-    assertSelectionIsEqualOnRandomData(
+    assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> coveredBy(candidate, context))
             .collect(toList()),
@@ -626,7 +626,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithCoveringPredicateOnRandomData() throws Exception
   {
-    assertSelectionIsEqualOnRandomData(
+    assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> covering(candidate, context))
             .collect(toList()),
@@ -655,7 +655,7 @@ public class SelectFsTest {
   @Test
   public void thatSelectFsBehaviorAlignsWithColocatedPredicateOnRandomData() throws Exception
   {
-    assertSelectionIsEqualOnRandomData(
+    assertSelectionIsEqualOnRandomData(30, 10,
         (cas, type, context) -> cas.getAnnotationIndex(type).select()
             .filter(candidate -> colocated(candidate, context))
             .collect(toList()),


### PR DESCRIPTION
- Fixed issue that relevant annotations might be skipped if they occur before the boundary annotation in the index
- Fixed issue that the boundary annotation might be in the result list although it shouldn't be included
- Fixed issue that an unchecked bounds check may trigger a NoSuchElementException because the iterator has become invalid
- Added several test cases derived from the case provided with the original issue report - in particular without using any of uimaFIT