### PR TITLE
[NO JIRA] Remove Eclipse Maven Repo

### DIFF
--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -73,22 +73,6 @@
        This allows maven to find the snapshots when looking for the parent of
        this pom -->
   <repositories>
-    <repository>
-      <id>eclipsePlugins</id>
-      <name>Eclipse components</name>
-      <layout>default</layout>
-      <url>https://repo1.maven.org/eclipse</url>
-      
-      <releases>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
-      </releases>
-      
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
     <!-- modify central repository access:
          Turn on checksum checking-->
     <repository>


### PR DESCRIPTION
- This repo no longer exists and checking it just makes the build turn longer