### PR TITLE
[UIMA-6313] PearSpecifier_impl methods return null despite promise not to do so

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/resource/PearSpecifier.java
+++ b/uimaj-core/src/main/java/org/apache/uima/resource/PearSpecifier.java
@@ -57,6 +57,7 @@ public interface PearSpecifier extends ResourceServiceSpecifier {
    * @deprecated These parameters only support string values. Better use
    *             {@link #getPearParameters}.
    */
+  @Deprecated
   public Parameter[] getParameters();
 
   /**
@@ -69,6 +70,7 @@ public interface PearSpecifier extends ResourceServiceSpecifier {
    * @deprecated These parameters only support string values. Better use
    *             {@link #setPearParameters}.
    */
+  @Deprecated
   public void setParameters(Parameter... parameters);
   
   /**
@@ -84,7 +86,7 @@ public interface PearSpecifier extends ResourceServiceSpecifier {
    * </pearParameters>
    * }</pre>
    * 
-   * @return an array of pearParameters.  This will never return <code>null</code>.
+   * @return an array of pearParameters. This will never return <code>null</code>.
    */
   public NameValuePair[] getPearParameters();
 

--- a/uimaj-core/src/main/java/org/apache/uima/resource/impl/PearSpecifier_impl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/resource/impl/PearSpecifier_impl.java
@@ -46,32 +46,47 @@ public class PearSpecifier_impl extends MetaDataObject_impl implements PearSpeci
   public PearSpecifier_impl() {
   }
 
+  @Override
   @Deprecated
   public Parameter[] getParameters() {
+    if (this.mParameters == null) {
+      return new Parameter[0];
+    }
+
     return this.mParameters;
   }
   
+  @Override
   public NameValuePair[] getPearParameters() {
+    if (this.mPearParameters == null) {
+      return new NameValuePair[0];
+    }
+    
     return this.mPearParameters;
   }
 
+  @Override
   @Deprecated
   public void setParameters(Parameter... parameters) {
     this.mParameters = parameters;
   }
   
+  @Override
   public void setPearParameters(NameValuePair... pearParameters) {
     this.mPearParameters = pearParameters;
   }
 
+  @Override
   public String getPearPath() {
     return this.mPearPath;
   }
 
+  @Override
   public void setPearPath(String aPearPath) {
     this.mPearPath = aPearPath;    
   }
 
+  @Override
   protected XmlizationInfo getXmlizationInfo() {
     return XMLIZATION_INFO;
   }


### PR DESCRIPTION
- Ensure to return a non-null value even if the internal field is null.