### PR TITLE
UIMA-6318: Deserialization of array subtypes fails (form6)

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes6.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes6.java
@@ -1478,7 +1478,7 @@ public class BinaryCasSerDes6 implements SlotKindsConstants {
     private void addModifiedStrings() {
 //      System.out.println("Enter addModifiedStrings");
       for (FsChange changedFs : modifiedFSs) {
-        final TOP fs = (TOP) changedFs.fs;
+        final TOP fs = changedFs.fs;
         final TypeImpl srcType = fs._getTypeImpl();
         if (isTypeMapping && null == typeMapper.mapTypeSrc2Tgt(srcType)) {
           continue; // skip this fs - it's not in target type system
@@ -2064,8 +2064,9 @@ public class BinaryCasSerDes6 implements SlotKindsConstants {
         break;
       
       case Slot_HeapRef: {
-        FSArray fsa = (FSArray)fs;
-        int prev = getPrevIntValue(TypeSystemConstants.fsArrayTypeCode, 0);
+        FSArray fsa = (FSArray) fs;
+        TypeImpl_array arrayType = (TypeImpl_array) fsa._getTypeImpl();
+        int prev = getPrevIntValue(arrayType.getCode(), 0);
         for (int i = 0; i < length; i++) {
           final int v = readDiff(Slot_HeapRef, prev);
           prev = v;
@@ -2884,7 +2885,7 @@ public class BinaryCasSerDes6 implements SlotKindsConstants {
         }
       }
     }
-    TypeImpl topType = (TypeImpl) cas1.getTypeSystemImpl().getTopType();
+    TypeImpl topType = cas1.getTypeSystemImpl().getTopType();
 
     // write (id's only, for index info) and/or enqueue indexed FSs, either all, or (for delta writes) the added/deleted/reindexed ones
     cas1.forAllViews(view -> {
@@ -3413,7 +3414,9 @@ public class BinaryCasSerDes6 implements SlotKindsConstants {
    * @return 0 or the mapped src id
    */
   private int getTgtSeqFromSrcFS(TOP fs) {
-    if (null == fs) return 0;
+    if (null == fs) {
+      return 0;
+    }
     if (isTypeMapping) {
       if (typeMapper.mapTypeSrc2Tgt(fs._getTypeImpl()) == null) {
         return 0;

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/CasTypeSystemMapperTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/CasTypeSystemMapperTest.java
@@ -54,7 +54,7 @@ import junit.framework.TestCase;
  *   Verify appropriate mapping is there.
  */
 
-public class CasTypeSystemMapperTst extends TestCase {
+public class CasTypeSystemMapperTest extends TestCase {
   
   private static TypeSystemImpl tsi = (TypeSystemImpl) CASFactory.createTypeSystem();  // just to get the built-ins
   private static int t0 = tsi.getNumberOfTypes();

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/OrderedFsSet_array_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/OrderedFsSet_array_Test.java
@@ -47,7 +47,7 @@ import org.apache.uima.util.XMLInputSource;
 
 import junit.framework.TestCase;
 
-public class OrderedFsSet_array_test extends TestCase {
+public class OrderedFsSet_array_Test extends TestCase {
 
   static File typeSystemFile1 = JUnitExtension.getFile("ExampleCas/testTypeSystem.xml");
   static int SZ = 23;

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsNoJCasTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SelectFsNoJCasTest.java
@@ -36,7 +36,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 // tests without initializing JCas
-public class SelectFsTestNoJCas  {
+public class SelectFsNoJCasTest  {
 
   private static TypeSystemDescription typeSystemDescription;
   

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm4Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm4Test.java
@@ -73,7 +73,7 @@ import junit.framework.TestCase;
  * Has main method for creating resources to use in testing
  *   will update resources in SerDes4.  If you do this by mistake, just revert those resources.
  */
-public class SerDesTest4 extends SerDesTstCommon {
+public class SerDesForm4Test extends SerDesTstCommon {
 
   // FIXME need to understand why includeUid is false, seems to be disabling some testing Nov 2016
   private static final boolean includeUid = false;
@@ -263,7 +263,7 @@ public class SerDesTest4 extends SerDesTstCommon {
     }
   }
 
-  public SerDesTest4() {
+  public SerDesForm4Test() {
   }
 
   public void setUp() {

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6ExtraTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6ExtraTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.impl;
+
+import static org.apache.uima.UIMAFramework.getResourceSpecifierFactory;
+import static org.apache.uima.cas.CAS.TYPE_NAME_ANNOTATION;
+import static org.apache.uima.cas.CAS.TYPE_NAME_FS_ARRAY;
+import static org.apache.uima.cas.SerialFormat.COMPRESSED_FILTERED_TSI;
+import static org.apache.uima.cas.SerialFormat.XMI;
+import static org.apache.uima.util.CasCreationUtils.createCas;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.apache.uima.cas.ArrayFS;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.TypeSystem;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasIOUtils;
+import org.junit.Test;
+
+public class SerDesForm6ExtraTest {
+  private final static String TYPE_NAME_ELEMENT = "Element";
+  private final static String TYPE_NAME_ARRAY_HOLDER = "ArrayHolder";
+
+  private final static String FEATURE_NAME_ARRAY = "array";
+
+  private final static String NO_DESCRIPTION = "";
+
+  @Test
+  public void thatArraySubtypesCanBeDeserialized() throws Exception {
+    TypeSystemDescription tsd = getResourceSpecifierFactory().createTypeSystemDescription();
+    tsd.addType(TYPE_NAME_ELEMENT, NO_DESCRIPTION, TYPE_NAME_ANNOTATION);
+    TypeDescription arrayHolderTypeDesc = tsd.addType(TYPE_NAME_ARRAY_HOLDER, NO_DESCRIPTION,
+        TYPE_NAME_ANNOTATION);
+    arrayHolderTypeDesc.addFeature(FEATURE_NAME_ARRAY, NO_DESCRIPTION, TYPE_NAME_FS_ARRAY,
+        TYPE_NAME_ELEMENT, null);
+
+    
+    CAS cas = createCas(tsd, null, null);
+    cas.setDocumentText("This is a test.");
+
+    TypeSystem ts = cas.getTypeSystem();
+    Type elementType = cas.getTypeSystem().getType(TYPE_NAME_ELEMENT);
+    Type holderType = cas.getTypeSystem().getType(TYPE_NAME_ARRAY_HOLDER);
+
+    // BEGIN: Setup CAS so that the reference to element1 in holder1 is encoded as a negative delta
+    // during binary serialization
+    AnnotationFS element1 = cas.createAnnotation(elementType, 0, cas.getDocumentText().length());
+    AnnotationFS element2 = cas.createAnnotation(elementType, 0, cas.getDocumentText().length());
+    
+    AnnotationFS holder2 = cas.createAnnotation(holderType, 0, 0);
+    ArrayFS<FeatureStructure> array2 = cas.createArrayFS(1);
+    array2.set(0, element2);
+    holder2.setFeatureValue(holderType.getFeatureByBaseName(FEATURE_NAME_ARRAY), array2);
+    
+    AnnotationFS holder1 = cas.createAnnotation(holderType, 1, 1);
+    ArrayFS<FeatureStructure> array1 = cas.createArrayFS(1);
+    array1.set(0, element1);
+    holder1.setFeatureValue(holderType.getFeatureByBaseName(FEATURE_NAME_ARRAY), array1);
+
+    cas.addFsToIndexes(element1);
+    cas.addFsToIndexes(element2);
+    cas.addFsToIndexes(holder2);
+    cas.addFsToIndexes(holder1);
+    // END: Setup CAS so that the reference to element1 in holder1 is encoded as a negative delta
+    
+    // BEGIN: Setup Element[] type
+    // We cannot directly create array subtypes - but they are created during de-serialization
+    // e.g. of XMI files. So to trigger the creation of the Element[] type in the CAS, we need
+    // to serialize to CAS and then back again.
+    byte[] xmiData;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+      CasIOUtils.save(cas, bos, XMI);
+      xmiData = bos.toByteArray();
+    }
+    
+    // While deserializing the XMI, the specific array subtype "Element[]" should be created
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(xmiData)) {
+      CasIOUtils.load(bis, cas);
+    }
+    
+    Type elementArrayType = cas.getTypeSystem().getArrayType(elementType);
+    assertThat(elementArrayType).isNotNull();
+    // END: Setup Element[] type
+    
+    
+    // Now finally test whether form 6 serialization can handle the Element[] type and the negative
+    // delta reference
+    byte[] form6Data;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+      CasIOUtils.save(cas, bos, COMPRESSED_FILTERED_TSI);
+      form6Data = bos.toByteArray();
+    }
+    
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(form6Data)) {
+      Serialization.deserializeCAS(cas, bis, ts, null);
+    }
+  }
+}

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6ExtraTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6ExtraTest.java
@@ -50,6 +50,25 @@ public class SerDesForm6ExtraTest {
 
   @Test
   public void thatArraySubtypesCanBeDeserialized() throws Exception {
+
+    CAS cas = prepCasWithNegativeDeltaReference();
+    
+    // Now finally test whether form 6 serialization can handle the Element[] type and the negative
+    // delta reference
+    byte[] form6Data;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+      CasIOUtils.save(cas, bos, COMPRESSED_FILTERED_TSI);
+      form6Data = bos.toByteArray();
+    }
+    
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(form6Data)) {
+      TypeSystem ts = cas.getTypeSystem();
+      Serialization.deserializeCAS(cas, bis, ts, null);
+    }
+  }
+
+  private CAS prepCasWithNegativeDeltaReference() throws Exception
+  {
     TypeSystemDescription tsd = getResourceSpecifierFactory().createTypeSystemDescription();
     tsd.addType(TYPE_NAME_ELEMENT, NO_DESCRIPTION, TYPE_NAME_ANNOTATION);
     TypeDescription arrayHolderTypeDesc = tsd.addType(TYPE_NAME_ARRAY_HOLDER, NO_DESCRIPTION,
@@ -61,7 +80,6 @@ public class SerDesForm6ExtraTest {
     CAS cas = createCas(tsd, null, null);
     cas.setDocumentText("This is a test.");
 
-    TypeSystem ts = cas.getTypeSystem();
     Type elementType = cas.getTypeSystem().getType(TYPE_NAME_ELEMENT);
     Type holderType = cas.getTypeSystem().getType(TYPE_NAME_ARRAY_HOLDER);
 
@@ -99,23 +117,12 @@ public class SerDesForm6ExtraTest {
     // While deserializing the XMI, the specific array subtype "Element[]" should be created
     try (ByteArrayInputStream bis = new ByteArrayInputStream(xmiData)) {
       CasIOUtils.load(bis, cas);
-    }
+    }    
     
     Type elementArrayType = cas.getTypeSystem().getArrayType(elementType);
     assertThat(elementArrayType).isNotNull();
     // END: Setup Element[] type
     
-    
-    // Now finally test whether form 6 serialization can handle the Element[] type and the negative
-    // delta reference
-    byte[] form6Data;
-    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-      CasIOUtils.save(cas, bos, COMPRESSED_FILTERED_TSI);
-      form6Data = bos.toByteArray();
-    }
-    
-    try (ByteArrayInputStream bis = new ByteArrayInputStream(form6Data)) {
-      Serialization.deserializeCAS(cas, bis, ts, null);
-    }
+    return cas;
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6Test.java
@@ -18,14 +18,14 @@
  */
 package org.apache.uima.cas.impl;
 
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.EqTwoTypes;
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.OneType;
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.OneTypeSubsetFeatures;
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.TwoTypes;
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.TwoTypesNoFeatures;
-import static org.apache.uima.cas.impl.SerDesTest6.TypeSystems.TwoTypesSubsetFeatures;
-import static org.apache.uima.cas.impl.SerDesTest6.Types.Akof1;
-import static org.apache.uima.cas.impl.SerDesTest6.Types.Akof2;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.EqTwoTypes;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.OneType;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.OneTypeSubsetFeatures;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.TwoTypes;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.TwoTypesNoFeatures;
+import static org.apache.uima.cas.impl.SerDesForm6Test.TypeSystems.TwoTypesSubsetFeatures;
+import static org.apache.uima.cas.impl.SerDesForm6Test.Types.Akof1;
+import static org.apache.uima.cas.impl.SerDesForm6Test.Types.Akof2;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -70,15 +70,11 @@ import junit.framework.TestCase;
 
 /**
  * Serializer and Deserializer testing
- * 
- * 
  */
-public class SerDesTest6 extends SerDesTstCommon {
+public class SerDesForm6Test extends SerDesTstCommon {
 
   /**
    * TwoType, EqTwoTypes, TwoTypesSubsetFeatures, TwoTypesNoFeatures have Akof1 and Akof2
-   *   
-   *
    */
   enum TypeSystems {
     TwoTypes,    // two types, Akof1 Akof2, with all features, one type system

--- a/uimaj-core/src/test/java/org/apache/uima/cas/test/GrowingTheCasNoJcasCacheTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/test/GrowingTheCasNoJcasCacheTest.java
@@ -44,7 +44,7 @@ import junit.framework.TestCase;
  * Class comment for IteratorTest.java goes here.
  * 
  */
-public class GrowingTheCasTestNoJcasCache extends TestCase {
+public class GrowingTheCasNoJcasCacheTest extends TestCase {
   
   private final static int REPETITIONS = 1;
 
@@ -52,7 +52,7 @@ public class GrowingTheCasTestNoJcasCache extends TestCase {
 
   private JCas smallHeapCas = null;
 
-  public GrowingTheCasTestNoJcasCache(String arg0) {
+  public GrowingTheCasNoJcasCacheTest(String arg0) {
     super(arg0);
   }
 
@@ -172,7 +172,7 @@ public class GrowingTheCasTestNoJcasCache extends TestCase {
   }
 
   public static void main(String[] args) {
-    junit.textui.TestRunner.run(GrowingTheCasTestNoJcasCache.class);
+    junit.textui.TestRunner.run(GrowingTheCasNoJcasCacheTest.class);
   }
 
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/test/IteratorSortedTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/test/IteratorSortedTest.java
@@ -70,7 +70,7 @@ import junit.framework.TestCase;
  *    
  * 
  */
-public class IteratorTestSorted extends TestCase {
+public class IteratorSortedTest extends TestCase {
   static final int REPETITIONS = // 100_000_000; 1000 secs = 17 min
                                   100_000;  // 1 second + startup time ~ .8 sec
 //                                    1000000;
@@ -126,7 +126,7 @@ public class IteratorTestSorted extends TestCase {
   }
   
  
-  public IteratorTestSorted(String arg) {
+  public IteratorSortedTest(String arg) {
     super(arg);
   }
   

--- a/uimaj-core/src/test/java/org/apache/uima/internal/util/rb_trees/Int2IntRBTTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/internal/util/rb_trees/Int2IntRBTTest.java
@@ -29,7 +29,7 @@ import org.apache.uima.internal.util.IntListIterator;
 
 import junit.framework.TestCase;
 
-public class Int2IntRBTtest extends TestCase {
+public class Int2IntRBTTest extends TestCase {
   
   public void testexpand() {
     Int2IntRBT ia = new Int2IntRBT();

--- a/uimaj-core/src/test/java/org/apache/uima/internal/util/rb_trees/IntArrayRBTTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/internal/util/rb_trees/IntArrayRBTTest.java
@@ -27,7 +27,7 @@ import org.apache.uima.internal.util.IntListIterator;
 
 import junit.framework.TestCase;
 
-public class IntArrayRBTtest extends TestCase {
+public class IntArrayRBTTest extends TestCase {
   private final static int NIL = 0;
   static final Random rand = new Random();    
   static {  

--- a/uimaj-core/src/test/java/org/apache/uima/pear/util/PearInstallationVerificationTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/pear/util/PearInstallationVerificationTest.java
@@ -41,7 +41,7 @@ import org.junit.rules.TemporaryFolder;
 /**
  * Test the pear installation verification
  */
-public class TestPearInstallationVerification {
+public class PearInstallationVerificationTest {
 
   // Temporary working directory, used to install the pear package
   public @Rule TemporaryFolder temp = new TemporaryFolder();

--- a/uimaj-core/src/test/java/org/apache/uima/util/impl/Log4jLogger_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/util/impl/Log4jLogger_implTest.java
@@ -32,7 +32,7 @@ import junit.framework.TestCase;
 /**
  * UIMA Logging Test
  */
-public class TestLog4jLogger_impl extends TestCase {
+public class Log4jLogger_implTest extends TestCase {
 
    @Override
   public void setUp() throws Exception {
@@ -210,7 +210,7 @@ public class TestLog4jLogger_impl extends TestCase {
          nbrcalls[0] ++;
          StackTraceElement ste = event.getSource();
          System.out.printf("[%s:%s] %s%n", ste.getFileName(), ste.getLineNumber(), event.getMessage().getFormattedMessage());
-         assertEquals(TestLog4jLogger_impl.this.getClass().getName() , ste.getClassName());
+         assertEquals(Log4jLogger_implTest.this.getClass().getName() , ste.getClassName());
          return Result.DENY;
        }
      };
@@ -321,7 +321,7 @@ public class TestLog4jLogger_impl extends TestCase {
          nbrcalls[0] ++;
          StackTraceElement ste = event.getSource();
          System.out.printf("[%s:%s] %s%n", ste.getFileName(), ste.getLineNumber(), event.getMessage().getFormattedMessage());
-         assertEquals(TestLog4jLogger_impl.this.getClass().getSimpleName()+".java", ste.getFileName());
+         assertEquals(Log4jLogger_implTest.this.getClass().getSimpleName()+".java", ste.getFileName());
          return Result.DENY;
        }
     }; 


### PR DESCRIPTION
- Rename tests so that Maven actually finds and executes them