### PR TITLE
[UIMA-6322] Clean up rat configuration v2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,5 +20,5 @@
 defaultPipeline {
   // The Eclipse libraries that our plugins depend unfortunately on required Java 11
   jdk = 'jdk_11_latest'
-  extraMavenArguments = '-Pjacoco,pmd'
+  extraMavenArguments = '-Pjacoco,pmd,run-rat-report'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -230,15 +230,30 @@
         </executions>
       </plugin>
     
-      <plugin>
+      <plugin> 
+        <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>uima-distr</id>
+                <configuration>
+                  <descriptors>
+                    <descriptor>${assemblyBinDescriptor}</descriptor>
+                  </descriptors>
+                </configuration>              
+              </execution>
+            </executions>
+          </plugin>
+       </plugins>
+  
+    <pluginManagement>
+      <plugins>
+        <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <executions>
             <execution>
               <id>default-cli</id>
-              <goals><goal>check</goal></goals>
-              <phase>verify</phase>
-              <!-- default configuration -->
+                <!-- default configuration -->
               <configuration>
                 <excludes combine.children="append">
                   <exclude>src/main/resources/docbook-shared/titlepage/*.xsl</exclude>
@@ -268,23 +283,9 @@
               </configuration>
             </execution>
           </executions>
-      </plugin>
-    
-      <plugin> 
-        <artifactId>maven-assembly-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>uima-distr</id>
-                <configuration>
-                  <descriptors>
-                    <descriptor>${assemblyBinDescriptor}</descriptor>
-                  </descriptors>
-                </configuration>              
-              </execution>
-            </executions>
-          </plugin>
-         
-     </plugins>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -241,14 +241,8 @@
               <!-- default configuration -->
               <configuration>
                 <excludes combine.children="append">
-                  <exclude>release.properties</exclude> <!-- generated file -->
-                  <exclude>README*</exclude>
-                  <exclude>RELEASE_NOTES*</exclude>
-                  <exclude>issuesFixed/**</exclude> <!-- generated file -->
                   <exclude>src/main/resources/docbook-shared/titlepage/*.xsl</exclude>
-                  <exclude>marker-file-identifying-*</exclude> <!-- empty file -->
-                  <exclude>DEPENDENCIES</exclude>  <!-- generated file -->
-                  <exclude>.idea/**</exclude>
+                  <exclude>src/main/readme/NOTICE-without-jackson</exclude>
                   
                   <!--  workaround https://issues.apache.org/jira/browse/RAT-97 -->
                   <exclude>aggregate-uimaj*/**</exclude>
@@ -270,7 +264,6 @@
                   <exclude>uimaj-bootstrap/**</exclude>
                   <exclude>uimaj-internal-tools/**</exclude>
                   <exclude>uimaj-json/**</exclude>
-                  <exclude>src/main/readme/NOTICE-without-jackson</exclude>
                </excludes>
               </configuration>
             </execution>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -100,6 +100,7 @@
                 <excludes combine.children="append">
                   <exclude>checkpoint_synchPoint.xml*</exclude> <!-- test data -->
                   <exclude>checkpoint.dat*</exclude> <!-- test data -->
+                  <exclude>src/test/resources/pearTests/pearForCPMtest.pear</exclude> <!-- binary -->
                 </excludes>
               </configuration>
             </execution>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -97,12 +97,10 @@
             <execution>
               <id>default-cli</id>
               <configuration>
-                <excludes>
-                  <exclude>release.properties</exclude> <!-- release generated artifact -->
+                <excludes combine.children="append">
                   <exclude>checkpoint_synchPoint.xml*</exclude> <!-- test data -->
                   <exclude>checkpoint.dat*</exclude> <!-- test data -->
-                  <exclude>marker-file-identifying-*</exclude>
-                </excludes>              
+                </excludes>
               </configuration>
             </execution>
           </executions>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -308,9 +308,7 @@
               <id>default-cli</id>
               <configuration>
                 <excludes combine.children="append">
-                  <exclude>release.properties</exclude> <!-- release generated artifact -->
                   <exclude>src/test/resources/ManualTests/*</exclude> <!-- test data -->
-                  <exclude>marker-file-identifying-*</exclude>
                 </excludes>              
               </configuration>
             </execution>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -304,9 +304,7 @@
               <id>default-cli</id>
               <configuration>
                 <excludes combine.children="append">
-                  <exclude>release.properties</exclude> <!-- release generated artifact -->
                   <exclude>src/test/resources/ManualTests/*</exclude> <!-- test data -->
-                  <exclude>marker-file-identifying-*</exclude>
                 </excludes>              
               </configuration>
             </execution>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -115,11 +115,12 @@
               <id>default-cli</id>
               <configuration>
                 <excludes combine.children="append">
-                  <exclude>src/main/data/*.txt</exclude> <!-- sample data -->
-                  <exclude>src/main/run_configuration/*.launch</exclude> <!-- generated Eclipse launch files -->
-                  <exclude>src/main/eclipseProject/*readme.txt</exclude> <!-- readme -->
-                  <exclude>src/main/resources/org/apache/uima/tutorial/ex6/*.txt</exclude> <!-- sample data -->
-                </excludes>              
+                  <!-- sample data -->
+                  <exclude>src/main/data/*.txt</exclude> 
+                  <exclude>src/main/resources/org/apache/uima/tutorial/ex6/*.txt</exclude>
+                  <!-- readme -->
+                  <exclude>src/main/eclipseProject/*readme.txt</exclude> 
+                </excludes>
               </configuration>
             </execution>
           </executions>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -76,13 +76,11 @@
 	            <execution>
 	              <id>default-cli</id>
 	              <configuration>
-	                <excludes>
-	                  <exclude>release.properties</exclude> <!-- generated file -->
-	                  <exclude>src/test/resources/CasSerialization/expected/json/*.txt</exclude>                  
-                    <exclude>src/test/resources/CasSerialization/expected/xmi/*.xml</exclude>                  
+	                <excludes combine.children="append">
+	                  <exclude>src/test/resources/CasSerialization/expected/json/*.txt</exclude>
+                    <exclude>src/test/resources/CasSerialization/expected/xmi/*.xml</exclude>
 	                  <exclude>src/test/resources/CASTests/json/expected/*.json</exclude>
 	                  <exclude>src/test/java/org/apache/uima/test/*.java</exclude>
-	                  <exclude>marker-file-identifying-*</exclude>              
 	               </excludes>
 	              </configuration>
 	            </execution>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -174,4 +174,40 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-cli</id>
+              <goals><goal>check</goal></goals>
+              <phase>verify</phase>
+              <!-- default configuration -->
+              <configuration>
+                <excludes combine.children="append">
+                  <exclude>.factorypath</exclude>
+                  <exclude>.idea/**</exclude>
+                  <!-- Eclipse launch files - no need for a license -->
+                  <exclude>**/run_configuration/*.launch</exclude>
+                  <!-- Maven profile trigger files -->
+                  <exclude>marker-file-identifying-*</exclude>
+                  <!-- Generated files -->
+                  <exclude>release.properties</exclude>
+                  <exclude>issuesFixed/**</exclude>
+                  <exclude>DEPENDENCIES</exclude>
+                  <!-- Simple documentation files not requiring an explicit licenese -->
+                  <exclude>README*</exclude>
+                  <exclude>RELEASE_NOTES*</exclude>
+               </excludes>
+              </configuration>
+            </execution>
+          </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+  
 </project>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -177,34 +177,25 @@
 
   <build>
     <plugins>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>default-cli</id>
-              <goals><goal>check</goal></goals>
-              <phase>verify</phase>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-cli</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
               <!-- default configuration -->
-              <configuration>
-                <excludes combine.children="append">
-                  <exclude>.factorypath</exclude>
-                  <exclude>.idea/**</exclude>
-                  <!-- Eclipse launch files - no need for a license -->
-                  <exclude>**/run_configuration/*.launch</exclude>
-                  <!-- Maven profile trigger files -->
-                  <exclude>marker-file-identifying-*</exclude>
-                  <!-- Generated files -->
-                  <exclude>release.properties</exclude>
-                  <exclude>issuesFixed/**</exclude>
-                  <exclude>DEPENDENCIES</exclude>
-                  <!-- Simple documentation files not requiring an explicit licenese -->
-                  <exclude>README*</exclude>
-                  <exclude>RELEASE_NOTES*</exclude>
-               </excludes>
-              </configuration>
-            </execution>
-          </executions>
+            <configuration>
+              <excludes combine.children="append">
+                <!-- Eclipse launch files - no need for a license -->
+                <exclude>**/run_configuration/*.launch</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Clean up rat configuration
- Enable rat on Jenkins builds
- Exclude PEAR file used during testing from rat check
- Remove rat excludes which are already included in the parent POM