### PR TITLE
[UIMA-6329] UIMA Java SDK 3.2.0 release

### DIFF
--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/PearPackagingMavenPlugin
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/PearPackagingMavenPlugin
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/PearPackagingMavenPlugin
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/PearPackagingMavenPlugin
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/README
+++ b/README
@@ -47,7 +47,8 @@ Supported Platforms
 
 Apache UIMA v3.0.0 and later requires Java version 8; it has been tested with Java 11 and Java 8.
 
-Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 8 or later.
+Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 11 or later
+(Java 8 may work but is no longer supported by recent Eclipse versions).
 
 Running the migration tool on class files requires running with a Java JDK, not a Java JRE.
 

--- a/README
+++ b/README
@@ -47,8 +47,7 @@ Supported Platforms
 
 Apache UIMA v3.0.0 and later requires Java version 8; it has been tested with Java 11 and Java 8.
 
-Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 11 or later
-(Java 8 may work but is no longer supported by recent Eclipse versions).
+Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 8 or later.
 
 Running the migration tool on class files requires running with a Java JDK, not a Java JRE.
 

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -108,6 +108,7 @@
   <li>Fixed concurrent binary serialization producing corrupt output</li>
   <li>Fixed deep cloning of AnalysisEngineDescription</li>
   <li>Fixed race condition in type system consolidation</li>
+  <li>Fixed re-initialization of multi-view CAS with a different type system</li>
   <li>No longer ship Pack200-compressed versions of the Eclipse plugins</li>
   <li>Converted UIMAv3 User's Guide from DocBook to Asciidoc</li>
 </ul>

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -109,6 +109,7 @@
   <li>Fixed deep cloning of AnalysisEngineDescription</li>
   <li>Fixed race condition in type system consolidation</li>
   <li>Fixed re-initialization of multi-view CAS with a different type system</li>
+  <li>Fixed logger silently discarding a parameter in some cases (placeholder filler or throwable)</li>
   <li>No longer ship Pack200-compressed versions of the Eclipse plugins</li>
   <li>Converted UIMAv3 User's Guide from DocBook to Asciidoc</li>
 </ul>

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -20,10 +20,10 @@
    -->
 <html>
 <head>
-  <title>Apache UIMA v3.1.0 Release Notes</title>
+  <title>Apache UIMA v3.2.0 Release Notes</title>
 </head>
 <body>
-<h1>Apache UIMA (Unstructured Information Management Architecture) v3.1.0 Release Notes</h1>
+<h1>Apache UIMA (Unstructured Information Management Architecture) v3.2.0 Release Notes</h1>
 
 <h2>Contents</h2>
 <p>
@@ -33,7 +33,7 @@
 <a href="#report.issues">How to Report Issues</a><br/>
 <a href="#list.issues">List of JIRA Issues Fixed in this Release</a><br/>
 </p>  
-        
+
 <h2><a id="what.is.uima">What is UIMA?</a></h2>
 
      <p>
@@ -79,21 +79,85 @@
 				for Perl, Python and TCL.
 			</p>
 
-<h2><a id="major.changes">Major Changes in this Release</a></h2>
+<h2><a id="major.changes">Notable changes in this release</a></h2>
 
-<p>Version 3.1.1 is a minor update to 3.1.0.
-</p>
-
-<p>Specific changes in release 3.1.1 versus 3.1.0 include</p>
 <ul>
-  <li>Migrated to Git from SVN, updated poms to reflect this</li>
-  <li>Fixed a performance bug when working with 100's of CASs with the same type system</li>
+  <li>Added AnnotationPredicates utility class providing various predicates testing how annotations
+      relate to each other (e.g. covering, being covered by, following, preceding, etc.)</li>
+  <li>Added single-int arg version of select.startAt()</li>
+  <li>Added trim method to AnnotationFS</li>
+  <li>Added ability to serialize as XMIs as XML 1.1</li>
+  <li>Added typed parameter support to PEARs</li>
+  <li>Improve performance of setting up JCas classes by reducing sync lock contention</li>
+  <li>Improved speed of constructing aggregate engines</li>
+  <li>Fixed de-serialization of array subtypes in form 6 binary CASes</li>
+  <li>Fixed parameter-fetching methods PearSpecifier_impl not returning null because they promise not to</li>
+  <li>Fixed logs being spammed with "Import by location/name..." messages</li>
+  <li>Fixed numerous bugs and inconsistencies in the SelectFS implementation</li>
+  <li>Fixed CAS-transportable Java objects not being properly deserialized</li>
+  <li>Fixed FSArray.spliterator() to work in PEAR scenarios</li>
+  <li>Fixed memory leak in FSClassRegistry in scenarios with large numbers of dynamically created classloaders</li>
+  <li>Fixed oddball "race" condition when initializing JCas classes</li>
+  <li>Fixed problem when reading mixed sets of binary CASes from UIMAv2 and UIMAv3</li>
+  <li>Fixed IndexOutOfBoundsException in CVD</li>
+  <li>Fixed bug causing Annotation to be returned when asking JCas for a specific type</li>
+  <li>Fixed ability to install PEARs into directories containing XML special characters in the name</li>
+  <li>Fixed not-indexed document annotation being wrongly added back to the index during de-serialization</li>
+  <li>Fixed index protection for cases that no FSes were indexed</li>
+  <li>Fixed concurrent binary serialization producing corrupt output</li>
+  <li>Fixed deep cloning of AnalysisEngineDescription</li>
+  <li>No longer ship Pack200-compressed versions of the Eclipse plugins</li>
+  <li>Converted UIMAv3 User's Guide from DocBook to Asciidoc</li>
 </ul>
  
 <h3>API changes</h3>
 
- <p>None this release.
- </p>
+<h4>SelectFS API with zero-width annotations</h4>
+
+<p>The behavior of the selectFS API changes in this release, in particular with respect to the 
+handling of zero-width annotations (those that have the same start and end position). The behavior
+has been made to align with the new annotation predicates, the details of which are described in the
+UIMAv3 User's Guide.
+</p>
+
+<h4>SelectFS API with negative shift on bounded selections</h4>
+
+<p>The <code>shifted</code> operation can no longer be used to expand a selection beyond its
+selection boundaries. Consider the following example:<p>
+
+<pre><code>
+t1 = new Token(0,1)
+t2 = new Token(2,3)
+t3 = new Token(4,5)
+t4 = new Token(6,7)
+t5 = new Token(8,9)
+</code></pre>
+
+<p>In previous versions, was also possible to use a negative shift with a bounding operator such as
+<code>following</code>, <code>coveredBy</code>, etc. and it would call <code>moveToPrevious</code>
+on the internal iterator of the selection operation, causing it to return annotations occurring
+before the bounds e.g.:
+
+<pre><code>
+select().shifted(-1).following(t3) => {t3, t4, t5}
+</code></pre>
+
+<p>This was found to be inconsistent behavior. The iterator used for the selection (which can also be 
+obtained by calling <code>fsIterator()</code>) should respect the bounds.</p>
+
+<p>As of this UIMA version, using <code>shifted</code> with a negative argument in conjunction with
+a bounding operator will trigger a warning in the logs and return an empty result.</p>
+
+<pre><code>
+select().shifted(-1).following(t3) => {}
+select().following(t3) => {t4, t5}
+</code></pre>
+
+<h4>SelectFS API with Backwards selection with startAt</h4>
+
+<p>In previous versions, the using the <code>moveTo</code> operation backwards iterators obtained
+through <code>SelectFSs</code> did never ignore type priorities - even though <code>SelectFSs</code>
+by default should ignore them.</p>
  
 <h2><a id="list.issues">Full list of JIRA Issues affecting this Release</a></h2>
 Click <a href="issuesFixed/jira-report.html">issuesFixed/jira-report.hmtl</a> for the list of 
@@ -118,7 +182,5 @@ The Apache UIMA project uses JIRA for issue tracking.  Please report any
 issues you find at 
 <a href="http://issues.apache.org/jira/browse/uima">http://issues.apache.org/jira/browse/uima</a>
 </p>
-  
-    
 </body>
 </html>

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -107,6 +107,7 @@
   <li>Fixed index protection for cases that no FSes were indexed</li>
   <li>Fixed concurrent binary serialization producing corrupt output</li>
   <li>Fixed deep cloning of AnalysisEngineDescription</li>
+  <li>Fixed race condition in type system consolidation</li>
   <li>No longer ship Pack200-compressed versions of the Eclipse plugins</li>
   <li>Converted UIMAv3 User's Guide from DocBook to Asciidoc</li>
 </ul>

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -87,6 +87,7 @@
   <li>Added single-int arg version of select.startAt()</li>
   <li>Added trim method to AnnotationFS</li>
   <li>Added ability to serialize as XMIs as XML 1.1</li>
+  <li>Added ability to serialize as XMIs pretty-printed using CasIOUtils</li>
   <li>Added typed parameter support to PEARs</li>
   <li>Improve performance of setting up JCas classes by reducing sync lock contention</li>
   <li>Improved speed of constructing aggregate engines</li>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-docbooks
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -42,15 +42,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj-docbooks
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj-docbooks
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-docbooks
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-eclipse-plugins
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj-eclipse-plugins
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj-eclipse-plugins
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj-eclipse-plugins
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/aggregate-uimaj
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/aggregate-uimaj
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version> 
+    <version>3.2.1-SNAPSHOT</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version> 
+    <version>3.2.0</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +54,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jVinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version> 
+    <version>3.2.0</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version> 
+    <version>3.2.1-SNAPSHOT</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -46,15 +46,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/jVinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/jVinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/jVinci
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version> 
+    <version>3.2.0</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +54,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.2.1-SNAPSHOT</version>
+		<version>3.2.0</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1-SNAPSHOT</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/jcasgen-maven-plugin
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/jcasgen-maven-plugin
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/jcasgen-maven-plugin
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jcasgen-maven-plugin
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.2.1-SNAPSHOT</version>
+		<version>3.2.0</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.uima</groupId>
 		<artifactId>uimaj-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1-SNAPSHOT</version>
 		<relativePath>../uimaj-parent/pom.xml</relativePath>
 	</parent>
   

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <artifactId>uimaj</artifactId>
   <packaging>pom</packaging>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
-  <description>The top project for the uimaj SDK</description>
+  <description>The top project for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
 
   <!-- Special inheritance note
@@ -62,7 +62,7 @@
 
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
-    <jiraVersion>3.1.1SDK</jiraVersion>   
+    <jiraVersion>3.2.0SDK</jiraVersion>   
     <assemblyFinalName>uimaj-${project.version}</assemblyFinalName> 
     <assemblyBinDescriptor>src/main/assembly/bin-without-jackson.xml</assemblyBinDescriptor> 
     <postNoticeText>${ibmNoticeText}</postNoticeText>    
@@ -272,18 +272,18 @@
     
       <plugin> 
         <artifactId>maven-assembly-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>uima-distr</id>
-                <configuration>
-                  <descriptors>
-                    <descriptor>${assemblyBinDescriptor}</descriptor>
-                  </descriptors>
-                </configuration>              
-              </execution>
-            </executions>
-          </plugin>
-       </plugins>
+        <executions>
+          <execution>
+            <id>uima-distr</id>
+            <configuration>
+              <descriptors>
+                <descriptor>${assemblyBinDescriptor}</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+   </plugins>
   
     <pluginManagement>
       <plugins>
@@ -373,7 +373,8 @@
     <profile>
       <id>json-support</id>
       <activation>
-        <file><exists>pom.xml</exists></file>  <!-- active by default, turn off via command line -P!json-support  -->
+        <!-- active by default, turn off via command line -P!json-support  -->
+        <file><exists>pom.xml</exists></file>
       </activation>
       <properties>
         <assemblyBinDescriptor>src/main/assembly/bin.xml</assemblyBinDescriptor>  

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -57,7 +57,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -57,7 +57,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -57,7 +57,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,17 +214,14 @@
   </modules>
   
   <build>
-
     <plugins>
-
-      <!-- This java doc config is for building the ones distributed with the bin packaging, and also 
-           posted on our website.  It is not a complete javadoc - it only has user-level API info.
+      <!-- This JavaDoc config is for building the ones distributed with the bin packaging, and also 
+           posted on our website.  It is not a complete JavaDoc - it only has user-level API info.
         
-           There is another javadoc config in the parent POM that builds all the java docs - intended
+           There is another JavaDoc config in the parent POM that builds all the java docs - intended
            for use by developers (currently not used) 
            
-           There is also a javadoc config for each individual maven Jar artifact -->
-      
+           There is also a JavaDoc config for each individual Maven Jar artifact -->
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <executions>

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -42,15 +42,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-v3-users-guide
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-v3-users-guide
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-v3-users-guide
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-v3-users-guide
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -42,15 +42,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-overview-and-setup
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-overview-and-setup
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-overview-and-setup
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-overview-and-setup
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
+++ b/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
@@ -50,7 +50,7 @@ under the License.
       <listitem><para>importing the example UIMA code into an Eclipse project. </para>
         </listitem></itemizedlist></para>
   
-  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 3.3 or
+  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 4.10 (2018-12) or
     later.
   </para>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -42,15 +42,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-references
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-references
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-references
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-references
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -42,15 +42,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tools
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tutorials-and-users-guides
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -50,7 +50,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -42,15 +42,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-tutorials-and-users-guides
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-tutorials-and-users-guides
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-tutorials-and-users-guides
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-adapter-soap
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-adapter-soap
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-soap
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-soap
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-vinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-adapter-vinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-adapter-vinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-adapter-vinci
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -36,15 +36,15 @@
   
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-bootstrap
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-bootstrap
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-bootstrap
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-bootstrap
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-component-test-util
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-component-test-util
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-component-test-util
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-component-test-util
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-core
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-core
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-core
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-core
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-cpe
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-cpe
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-cpe
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-cpe
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-document-annotation
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-document-annotation
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-document-annotation
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-document-annotation
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     
@@ -53,7 +53,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     
@@ -53,7 +53,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-runtime
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     
@@ -45,15 +45,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-eclipse-feature-runtime
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-eclipse-feature-runtime
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-runtime
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-eclipse-feature-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-eclipse-feature-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-feature-tools
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.0.1</version>
+    <version>3.2.0</version>
     <relativePath />
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.2.0</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>
@@ -45,7 +45,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-eclipse-update-site
     </url>
-    <tag>uimaj-eclipse-update-site-3.1.1</tag>
+    <tag>uimaj-eclipse-update-site-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -53,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor-ide
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,15 +43,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-cas-editor-ide
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-cas-editor-ide
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor-ide
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,15 +43,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-cas-editor
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-cas-editor
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -53,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-cas-editor
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-configurator
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-configurator
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-configurator
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-configurator
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -55,7 +53,7 @@ UIMA data structures to the Eclipse Debug displays</description>
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-debug
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -53,7 +53,7 @@ UIMA data structures to the Eclipse Debug displays</description>
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -45,15 +45,15 @@ UIMA data structures to the Eclipse Debug displays</description>
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-debug
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-debug
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-debug
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-jcasgen
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-jcasgen
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-jcasgen
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-jcasgen
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-launcher
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-launcher
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-launcher
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-launcher
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -44,15 +44,15 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-pear-packager
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-pear-packager
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-pear-packager
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -54,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-pear-packager
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <properties>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-runtime
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-runtime
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-ep-runtime
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-ep-runtime
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -115,17 +115,6 @@
     <finalName>uima-examples</finalName>
     <pluginManagement>
       <plugins>
-        <!-- 
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <compilerArgs>
-              <arg>-Xlint:deprecation</arg>
-              <arg>-Xlint:unchecked</arg>
-            </compilerArgs>
-          </configuration>
-        </plugin>
-        -->
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
@@ -134,6 +123,8 @@
               <id>default-cli</id>
               <configuration>
                 <excludes combine.children="append">
+                  <!-- Eclipse launch configurations -->
+                  <exclude>src/main/run_configuration/*.launch</exclude>
                   <!-- sample data -->
                   <exclude>src/main/data/*.txt</exclude> 
                   <exclude>src/main/resources/org/apache/uima/tutorial/ex6/*.txt</exclude>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-examples
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-examples
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-examples
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-examples
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-examples/src/main/run_configuration/UIMA CAS Visual Debugger.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA CAS Visual Debugger.launch
@@ -1,40 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.cvd.CVD"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Duima.tools.cvd.manpath=${env_var:UIMA_HOME}/docs/html&quot; &quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.cvd.CVD"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Duima.tools.cvd.manpath=${env_var:UIMA_HOME}/docs/html&quot; &quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Document Analyzer.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Document Analyzer.launch
@@ -1,38 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.docanalyzer.DocumentAnalyzer"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.docanalyzer.DocumentAnalyzer"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA JCasGen.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA JCasGen.launch
@@ -1,33 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.jcasgen.Jg"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/FileConsoleLogger.properties&quot;"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.jcasgen.Jg"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/FileConsoleLogger.properties&quot;"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA PEAR Installer.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA PEAR Installer.launch
@@ -1,38 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.pear.install.InstallPear"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.pear.install.InstallPear"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Run AE.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Run AE.launch
@@ -1,39 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.RunAE"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:AE Descriptor}&quot; &quot;${folder_prompt:Input Directory}&quot; &quot;${folder_prompt:Output Directory}&quot;"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.tools.RunAE"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:AE Descriptor}&quot; &quot;${folder_prompt:Input Directory}&quot; &quot;${folder_prompt:Output Directory}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Run CPE.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Run CPE.launch
@@ -1,39 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.examples.cpe.SimpleRunCPE"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:CPE Descriptor}&quot;"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.examples.cpe.SimpleRunCPE"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:CPE Descriptor}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Run V3 migrate JCas from classes roots.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Run V3 migrate JCas from classes roots.launch
@@ -1,29 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-classesRoots &quot;${folder_prompt:root dir for compiled classes and jars and PEARs}&quot;  &#13;&#10;-migrateClasspath ${project_classpath}"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-  <listEntry value="4"/>
-</listAttribute>
-
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-classesRoots &quot;${folder_prompt:root dir for compiled classes and jars and PEARs}&quot;  &#13;&#10;-migrateClasspath ${project_classpath}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Run V3 migrate JCas from sources roots.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Run V3 migrate JCas from sources roots.launch
@@ -1,29 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-sourcesRoots ${selected_resource_loc}&#13;&#10;-migrateClasspath ${project_classpath}"/>
-
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-  <listEntry value="4"/>
-</listAttribute>
-
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-sourcesRoots ${selected_resource_loc}&#13;&#10;-migrateClasspath ${project_classpath}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Start VNS.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Start VNS.launch
@@ -1,32 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.vinci.transport.vns.service.VNS"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.vinci.transport.vns.service.VNS"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/uimaj-examples/src/main/run_configuration/UIMA Start Vinci Service.launch
+++ b/uimaj-examples/src/main/run_configuration/UIMA Start Vinci Service.launch
@@ -1,39 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.adapter.vinci.VinciAnalysisEngineService_impl"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:Vinci Service Deployment Descriptor}&quot;"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="4"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
-<stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-examples"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
-<mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
-<mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
-<mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
-</mapAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-examples"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="DYLD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:DYLD_LIBRARY_PATH}"/>
+        <mapEntry key="LD_LIBRARY_PATH" value="${env_var:UIMA_HOME}/uimacpp/lib:${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src:${env_var:LD_LIBRARY_PATH}"/>
+        <mapEntry key="PATH" value="${env_var:UIMA_HOME}/uimacpp/bin;${env_var:UIMA_HOME}/uimacpp/examples/tutorial/src;${env_var:PATH}"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.debug.ui.target_debug_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.debug.ui.target_run_perspective" value="perspective_default"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.adapter.vinci.VinciAnalysisEngineService_impl"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;${file_prompt:Vinci Service Deployment Descriptor}&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="&quot;-Djava.util.logging.config.file=${env_var:UIMA_HOME}/config/Logger.properties&quot; -DVNS_HOST=localhost"/>
 </launchConfiguration>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>
@@ -30,10 +30,10 @@
   <description>JSON support for UIMA SDK</description>
   
   <scm>
-    <connection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</connection>
-    <developerConnection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</developerConnection>
-    <url>https://github.com/apache/uima-uimaj/tree/master/uimaj-json</url>
-    <tag>uimaj-3.2.0</tag>
+    <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
+    <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
+    <url>https://github.com/apache/uima-uimaj/</url>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/uimaj-json</developerConnection>
     <url>https://github.com/apache/uima-uimaj/tree/master/uimaj-json</url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.2.0</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -60,7 +60,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-parent
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <!-- The repositories and pluginRepositories section is duplicated from

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -52,15 +52,15 @@
        element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-parent
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-parent
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-parent
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- The repositories and pluginRepositories section is duplicated from

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.0</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -60,7 +60,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
 
   <!-- The repositories and pluginRepositories section is duplicated from

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -32,14 +32,14 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14-SNAPSHOT</version>
+    <version>14</version>
   </parent>
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
   <version>3.2.0-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
-  <description>The common parent pom for the uimaj SDK</description>
+  <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
 
   <!-- Special inheritance note
@@ -95,7 +95,6 @@
       - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
       - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only
       - be enabled when really needed.
-    -->
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
@@ -107,6 +106,7 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    -->
   </repositories>
   
   <pluginRepositories>
@@ -231,7 +231,6 @@
               <excludes combine.children="append">
                 <!-- Duplicates on classpath cause an exception in JaCoCo report -->
                 <exclude>**/org/apache/uima/examples/SourceDocumentInformation*</exclude>
-                <exclude>**/org/apache/uima/examples/SourceDocumentInformation_Type*</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -266,9 +265,7 @@
                     <pluginExecution>
                       <pluginExecutionFilter>
                         <groupId>org.apache.felix</groupId>
-                        <artifactId>
-                          maven-bundle-plugin
-                        </artifactId>
+                        <artifactId>maven-bundle-plugin</artifactId>
                         <versionRange>[3,)</versionRange>
                         <goals>
                           <goal>process</goal>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -217,19 +217,6 @@
         </executions>
       </plugin>
     </plugins>
-  
-    <pluginManagement>
-      <plugins>
-        <!-- https://issues.apache.org/jira/browse/UIMA-5367 -->
-        <plugin> 
-          <groupId>org.apache.maven.plugins</groupId> 
-          <artifactId>maven-deploy-plugin</artifactId>
-          <configuration> 
-            <retryFailedDeploymentCount>10</retryFailedDeploymentCount> 
-          </configuration> 
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
   
   <profiles>
@@ -262,7 +249,7 @@
       </activation>
       <build>
         <pluginManagement>
-          <plugins>         
+          <plugins>
             <!-- This plugin's configuration is used to store Eclipse m2e settings 
                 only. It has no influence on the Maven build itself. -->
             <plugin>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -37,7 +37,7 @@
 
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.2.0</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -44,15 +44,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/jvinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/jvinci
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/jvinci
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -52,7 +52,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/jvinci
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -43,15 +43,15 @@
        element, and just changing the following two properties -->  
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-tools
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-tools
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   
@@ -51,7 +51,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-tools
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <url>
       https://github.com/apache/uima-uimaj/tree/master/uimaj-jcas
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <url>
       https://github.com/apache/uima-uimaj/
     </url>
-    <tag>HEAD</tag>
+    <tag>uimaj-3.2.0</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -35,15 +35,15 @@
   
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-jcas
+      scm:git:https://github.com/apache/uima-uimaj/
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uimaj-jcas
+      scm:git:https://github.com/apache/uima-uimaj/
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uimaj-jcas
+      https://github.com/apache/uima-uimaj/
     </url>
-    <tag>uimaj-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/uimaj-v3migration-jcas/src/test/run_configuration/UIMA Run V3 migrate JCas from classes roots test.launch
+++ b/uimaj-v3migration-jcas/src/test/run_configuration/UIMA Run V3 migrate JCas from classes roots test.launch
@@ -1,32 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-v3migration-jcas/src/main/java/org/apache/uima/migratev3/jcas/MigrateJCas.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-classesRoots ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_compiled&#13;&#10;-migrateClasspath ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_compiled"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-v3migration-jcas"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-v3migration-jcas/src/main/java/org/apache/uima/migratev3/jcas/MigrateJCas.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-classesRoots ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_compiled&#13;&#10;-migrateClasspath ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_compiled"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-v3migration-jcas"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/uimaj-v3migration-jcas/src/test/run_configuration/UIMA Run V3 migrate JCas from sources roots test.launch
+++ b/uimaj-v3migration-jcas/src/test/run_configuration/UIMA Run V3 migrate JCas from sources roots test.launch
@@ -1,32 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.    
--->
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/uimaj-v3migration-jcas/src/main/java/org/apache/uima/migratev3/jcas/MigrateJCas.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-sourcesRoots ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_sources"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/uimaj-v3migration-jcas/src/main/java/org/apache/uima/migratev3/jcas/MigrateJCas.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.apache.uima.migratev3.jcas.MigrateJCas"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-sourcesRoots ${project_loc:/uimaj-v3migration-jcas}/src/test/v2_jcas_sources"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="uimaj-examples"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>


### PR DESCRIPTION
**Jira:** https://issues.apache.org/jira/browse/UIMA-6329

- Update README file for release
- Update RELEASE_NOTES.html for release
- Update Jira version in pom.xml for release
- Removed Maven deploy configuration which is already included in parent POM 14
- Update to UIMA Parent POM 14
- Comment out SNAPSHOT repo
- Remove JaCoCo exclude for UIMAv2 _Type file
- Bit of formatting / cleaning up comments