### PR TITLE
[UIMA-6328] UIMA Java SDK 2.11.0 release

### DIFF
--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -32,27 +32,6 @@
 	<name>Apache UIMA Maven: ${project.artifactId}</name>
   <description>This is a maven plugin that produces a pear artifact.</description>
   <url>${uimaWebsiteUrl}</url>
-
-
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/PearPackagingMavenPlugin
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/PearPackagingMavenPlugin
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/PearPackagingMavenPlugin
-    </url>
-  </scm>
   
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>

--- a/README
+++ b/README
@@ -92,8 +92,7 @@ Please refer to the RELEASE_NOTES.html
 Supported Platforms
 --------------------
 
-Apache UIMA requires Java version 8 or later; it has been tested with Sun/Oracle 8, 
-and IBM Java 8.
+Apache UIMA requires Java version 8 or later; it has been tested with OpenJDK 8.
 
 Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 8 or later, as well.
 

--- a/README
+++ b/README
@@ -94,7 +94,7 @@ Supported Platforms
 
 Apache UIMA requires Java version 8 or later; it has been tested with OpenJDK 8.
 
-Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 8 or later, as well.
+Running the Eclipse plugin tooling for UIMA requires you start Eclipse using a Java 8 or later.
 
 The supported platforms are: Windows, Linux, and Mac OS X. Other platforms and Java (8+) 
 implementations should work, but have not been significantly tested.

--- a/RELEASE_NOTES.html
+++ b/RELEASE_NOTES.html
@@ -20,10 +20,10 @@
    -->
 <html>
 <head>
-  <title>Apache UIMA v2.10.4 Release Notes</title>
+  <title>Apache UIMA v2.11.0 Release Notes</title>
 </head>
 <body>
-<h1>Apache UIMA (Unstructured Information Management Architecture) v2.10.4 Release Notes</h1>
+<h1>Apache UIMA (Unstructured Information Management Architecture) v2.11.0 Release Notes</h1>
 
 <h2>Contents</h2>
 <p>
@@ -82,13 +82,15 @@
 <h2><a id="major.changes">Major Changes in this Release</a></h2>
 <p>The major changes in this release include:</p>
 
-<ul> 
-  <li>The Eclipse plugin for the Component Descriptor editor was fixed to work with
-      the latest version of Eclipse.</li>
-  <li>Internationalized Exceptions more reliably find their message bundles.</li>
-  <li>An additional use case for running pipeline within pipelines is now supported.</li>
-  <li>An override was added to enable using External DTDs in XML descriptors.</li>
-  <li>The destroy cleanups around PEARs was improved.</li>
+<ul>
+  <li>Added ability to serialize as XMIs as XML 1.1</li>
+  <li>Added typed parameter support to PEARs</li>
+  <li>Improved speed of constructing aggregate engines</li>
+  <li>Fixed deep cloning of AnalysisEngineDescription</li>
+  <li>Fixed bug causing Annotation to be returned when asking JCas for a specific type</li>
+  <li>Fixed ability to install PEARs into directories containing XML special characters in the name</li>
+  <li>Fixed index protection for cases that no FSes were indexed</li>
+  <li>No longer ship Pack200-compressed versions of the Eclipse plugins</li>
 </ul>
   
 <h2><a id="list.issues">Full list of JIRA Issues Fixed in this Release</a></h2>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -31,26 +31,6 @@
 	<packaging>pom</packaging>
 	<name>Apache UIMA Aggregate: ${project.artifactId}</name>
   <url>${uimaWebsiteUrl}</url>
-
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-docbooks
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-docbooks
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-docbooks
-    </url>
-  </scm>
   
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>

--- a/aggregate-uimaj-docbooks/pom.xml
+++ b/aggregate-uimaj-docbooks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -34,26 +34,6 @@
     that are part of the base UIMA framework</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the
-       same as those in super poms, it cannot be inherited because
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted.
-
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-eclipse-plugins
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-eclipse-plugins
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj-eclipse-plugins
-    </url>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj-eclipse-plugins/pom.xml
+++ b/aggregate-uimaj-eclipse-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -33,26 +33,6 @@
   <description>The aggregate for the base UIMA framework build and release</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/aggregate-uimaj
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -69,14 +69,9 @@
     <module>../jVinci</module>
     <module>../aggregate-uimaj-eclipse-plugins</module>
     <module>../aggregate-uimaj-docbooks</module>
-    <!--module>distr-superPom</module-->
     <module>../uimaj-document-annotation</module>
     <module>../PearPackagingMavenPlugin</module>
     <module>../jcasgen-maven-plugin</module>
-    <!-- the internal tools project is not part of any release 
-         and can't be built automatically - to build it,
-         cd to the project directory and do mvn install -->
-    <!--module>../uimaj-internal-tools</module-->
     <module>../uimaj-bootstrap</module>    
   </modules>  
 </project>

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/aggregate-uimaj/pom.xml
+++ b/aggregate-uimaj/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/api-change-report.html
+++ b/api-change-report.html
@@ -31,7 +31,7 @@
 <a target="_blank" href="uimaj-core/api-change-report/japicmp.html">API Changes: uimaj-core</a><br/>
 <a target="_blank" href="uimaj-cpe/api-change-report/japicmp.html">API Changes: uimaj-cpe</a><br/>
 <a target="_blank" href="uimaj-json/api-change-report/japicmp.html">API Changes: uimaj-json</a><br/>
-<a href-"#running-more-reports">Running your own custom reports</a>
+<a href="#running-more-reports">Running your own custom reports</a>
 </p>  
    
 <h2><a id="description">What is an API change report?</a></h2>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -36,26 +36,6 @@
     more standard protocols.</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jVinci
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jVinci
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/jVinci
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version> 
+    <version>2.11.0</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version> 
+    <version>2.11.0</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version> 
+    <version>2.11.1-SNAPSHOT</version> 
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
 	<relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -34,26 +34,6 @@
 	<relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 
- <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the
-       same as those in super poms, it cannot be inherited because
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted.
-
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jcasgen-maven-plugin
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jcasgen-maven-plugin
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/jcasgen-maven-plugin
-    </url>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
 	<relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
 	<relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>
-    <tag>uimaj-2.11.0</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,26 +39,12 @@
   <description>The top project for the uimaj SDK</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the
-       same as those in super poms, it cannot be inherited because
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted.
-
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->
   <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/
-    </url>
+    <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
+    <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
+    <url>https://github.com/apache/uima-uimaj/</url>
   </scm>
-
+  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <jiraVersion>2.11.0SDK</jiraVersion>   <!-- set this to get the right issues fixed report -->

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
-    <jiraVersion>2.10.4SDK</jiraVersion>   <!-- set this to get the right issues fixed report -->
+    <jiraVersion>2.11.0SDK</jiraVersion>   <!-- set this to get the right issues fixed report -->
     <assemblyFinalName>uimaj-${project.version}</assemblyFinalName> 
     <assemblyBinDescriptor>src/main/assembly/bin-without-jackson.xml</assemblyBinDescriptor> 
     <postNoticeText>${ibmNoticeText}</postNoticeText>    
@@ -161,13 +161,12 @@
     </dependency>    
   </dependencies>
 
-  
   <modules>
     <module>uimaj-parent</module>
     <module>aggregate-uimaj</module>
   </modules>
   
-  <build>    
+  <build>
     <plugins>
 
       <!-- This java doc config is for building the ones distributed with the bin packaging, and also 
@@ -207,7 +206,7 @@
                 ${basedir}/uimaj-core/src/main/java/org/apache/uima/cas/impl/XmiCasDeserializer.java
                 ${basedir}/uimaj-core/src/main/java/org/apache/uima/cas/impl/XmiCasSerializer.java
                 ${basedir}/uimaj-core/src/main/java/org/apache/uima/cas/impl/XmiSerializationSharedData.java
-                ${basedir}/uimaj-core/src/main/java/org/apache/uima/cas/impl/Serialization.java                
+                ${basedir}/uimaj-core/src/main/java/org/apache/uima/cas/impl/Serialization.java
                 ${basedir}/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/metadata/cpe/CpeDescriptorFactory.java
                 ${basedir}/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMChunkTimeoutException.java
               </additionalparam>
@@ -239,7 +238,7 @@
                   <descriptors>
                     <descriptor>${assemblyBinDescriptor}</descriptor>
                   </descriptors>
-                </configuration>              
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -305,24 +304,24 @@
                   <fixVersionIds>${jiraVersion}</fixVersionIds>
                 </configuration>
               </execution>
-            </executions>  
+            </executions>
           </plugin>
-        </plugins>     
+        </plugins>
       </build>
     </profile>
     
     <profile>
       <id>json-support</id>
       <activation>
-        <file><exists>pom.xml</exists></file>  <!-- active by default, turn off via command line -P!json-support  -->
+        <!-- active by default, turn off via command line -P!json-support -->
+        <file><exists>pom.xml</exists></file>
       </activation>
       <properties>
-        <assemblyBinDescriptor>src/main/assembly/bin.xml</assemblyBinDescriptor>  
+        <assemblyBinDescriptor>src/main/assembly/bin.xml</assemblyBinDescriptor>
       </properties>
       <modules>
         <module>uimaj-json</module>
       </modules>
     </profile>
-  </profiles>    
-    
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>
-    <tag>HEAD</tag>
+    <tag>uimaj-2.11.0</tag>
   </scm>
   
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>uimaj-parent/pom.xml</relativePath>
   </parent>
 
@@ -43,6 +43,7 @@
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>
+    <tag>uimaj-2.11.0</tag>
   </scm>
   
   <properties>

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-overview-and-setup/pom.xml
+++ b/uima-docbook-overview-and-setup/pom.xml
@@ -32,26 +32,6 @@
 	<name>Apache UIMA SDK Documentation - overview and setup</name>	
   <url>${uimaWebsiteUrl}</url>
  
-   <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-overview-and-setup
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-overview-and-setup
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-overview-and-setup
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <!-- next property is the name of the top file under src/docbook without trailing .xml -->

--- a/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
+++ b/uima-docbook-overview-and-setup/src/docbook/eclipse_setup.xml
@@ -50,7 +50,7 @@ under the License.
       <listitem><para>importing the example UIMA code into an Eclipse project. </para>
         </listitem></itemizedlist></para>
   
-  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 3.3 or
+  <para>The UIMA Eclipse plugins are designed to be used with Eclipse version 4.10 (2018-12) or
     later.
   </para>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-references/pom.xml
+++ b/uima-docbook-references/pom.xml
@@ -32,26 +32,6 @@
 	<name>Apache UIMA SDK Documentation - references</name>	
   <url>${uimaWebsiteUrl}</url>
  
-   <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-references
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-references
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-references
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <!-- next property is the name of the top file under src/docbook without trailing .xml -->

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -32,26 +32,6 @@
 	<name>Apache UIMA SDK Documentation - tools</name>	
   <url>${uimaWebsiteUrl}</url>
  
-   <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tools
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tools
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tools
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <!-- next property is the name of the top file under src/docbook without trailing .xml -->

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tools/pom.xml
+++ b/uima-docbook-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uima-docbook-tutorials-and-users-guides/pom.xml
+++ b/uima-docbook-tutorials-and-users-guides/pom.xml
@@ -32,26 +32,6 @@
 	<name>Apache UIMA SDK Documentation - tutorials and user's guides</name>	
   <url>${uimaWebsiteUrl}</url>
  
-   <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tutorials-and-users-guides
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tutorials-and-users-guides
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uima-docbook-tutorials-and-users-guides
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <!-- next property is the name of the top file under src/docbook without trailing .xml -->

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -34,26 +34,6 @@
     component, using the SOAP protocol</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-soap
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-soap
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-soap
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-adapter-soap/pom.xml
+++ b/uimaj-adapter-soap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -34,26 +34,6 @@
     engine, using the Vinci protocol</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-vinci
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-vinci
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-adapter-vinci
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>    

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -34,18 +34,6 @@
     a Java application using that</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-bootstrap
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-bootstrap
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-bootstrap
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>uimaj-bootstrap</uimaScmProject>
   </properties>

--- a/uimaj-bootstrap/pom.xml
+++ b/uimaj-bootstrap/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -32,26 +32,6 @@
 	<name>Apache UIMA Base: ${project.artifactId}: for JUnit</name>
   <description>Supporting utilities used in various JUnit tests</description>
   <url>${uimaWebsiteUrl}</url>
-
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-component-test-util
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-component-test-util
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-component-test-util
-    </url>
-  </scm>
   
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -33,26 +33,6 @@
   <description>The core implementation of the UIMA Java Framework</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-core
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-core
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-core
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -34,26 +34,6 @@
     UIMA-AS a better scaleout mechanism.</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-cpe
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-cpe
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-cpe
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -34,26 +34,6 @@
     specifying the language of a document</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-document-annotation
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-document-annotation
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-document-annotation
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -35,26 +35,6 @@
     need UIMA framework code</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-runtime
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-runtime
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-runtime
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     

--- a/uimaj-eclipse-feature-runtime/pom.xml
+++ b/uimaj-eclipse-feature-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
     

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -32,26 +32,6 @@
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>
   <description>UIMA Eclipse Plugin Feature for base uima tooling</description>  
   <url>${uimaWebsiteUrl}</url>
-
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-tools
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-tools
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-feature-tools
-    </url>
-  </scm>
   
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>

--- a/uimaj-eclipse-feature-tools/pom.xml
+++ b/uimaj-eclipse-feature-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>  <!-- change to non-snapshot version after release of uimaj-parent -->
+    <version>2.11.0</version>  <!-- change to non-snapshot version after release of uimaj-parent -->
     <relativePath />
   </parent>
 
   <artifactId>uimaj-eclipse-update-site</artifactId>
-  <version>2.10.5-SNAPSHOT</version>
+  <version>2.11.0</version>
   <packaging>pom</packaging>
 
   <name>Apache UIMA Eclipse: ${project.artifactId}</name>

--- a/uimaj-eclipse-update-site/pom.xml
+++ b/uimaj-eclipse-update-site/pom.xml
@@ -35,18 +35,6 @@
   <description>The UIMA Java SDK Eclipse update site</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-update-site
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-eclipse-update-site
-    </url>
-  </scm>
-
   <properties>
     <uimaScmRoot>uimaj</uimaScmRoot>
     <uimaScmProject>${project.artifactId}</uimaScmProject>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -17,15 +17,13 @@
    specific language governing permissions and limitations
    under the License.    
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -35,27 +35,6 @@
   <description>Allows editing the contents of a saved CAS</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that computes the connection elements
-    from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor-ide
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor-ide
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor-ide
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -35,27 +35,6 @@
   <description>Allows editing the contents of a saved CAS</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that computes the connection elements
-    from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-cas-editor
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -36,27 +36,6 @@
     descriptors</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that incorrectly computes the
-    connection elements from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-configurator
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-configurator
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-configurator
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -17,15 +17,13 @@
    specific language governing permissions and limitations
    under the License.    
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -37,27 +37,6 @@
 UIMA data structures to the Eclipse Debug displays</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that incorrectly computes the
-    connection elements from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-debug
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-debug
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-debug
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -34,27 +34,6 @@
     the Component Descriptor Editor</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-jcasgen
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-jcasgen
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-jcasgen
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -36,27 +36,6 @@
   <description>Adds launch support for Analysis Engines </description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that incorrectly computes the
-    connection elements from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-launcher
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-launcher
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-launcher
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -17,15 +17,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
 

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -36,27 +36,6 @@
     a PEAR package</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-    even though the <scm> element that follows is exactly the
-    same as those in super poms, it cannot be inherited because
-    there is some special code that computes the connection elements
-    from the chain of parent poms, if this is omitted.
-
-    Keeping this a bit factored allows cutting/pasting the <scm>
-    element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-pear-packager
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-pear-packager
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-pear-packager
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -34,27 +34,6 @@
     plugins for their use</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that incorrectly computes the 
-       connection elements from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-runtime
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-runtime
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-ep-runtime
-    </url>
-    <tag>HEAD</tag>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -33,26 +33,6 @@
   <description>Examples and sample code</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-examples
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-examples
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-examples
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -29,12 +29,6 @@
   <name>Apache UIMA Base: ${project.artifactId}: JSON</name>
   <description>JSON support for UIMA SDK</description>
   
-  <scm>
-    <connection>scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-json</connection>
-    <developerConnection>scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-json</developerConnection>
-    <url>https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-json</url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
   </properties>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>

--- a/uimaj-json/pom.xml
+++ b/uimaj-json/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   <artifactId>uimaj-json</artifactId>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -40,7 +40,7 @@
   <packaging>pom</packaging>
   <version>2.10.5-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
-  <description>The common parent pom for the uimaj SDK</description>
+  <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
 
   <!-- Special inheritance note
@@ -96,7 +96,6 @@
       - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
       - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only
       - be enabled when really needed.
-    -->
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
@@ -108,6 +107,7 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    -->
   </repositories>
   
   <pluginRepositories>
@@ -135,14 +135,7 @@
   <properties>
     <uimaScmRoot>uimaj</uimaScmRoot>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
-    <!-- 
-     BACKWARD_COMPATIBLE_IMPLEMENTER - patch version (=.=.+)
-     BACKWARD_COMPATIBLE_USER        - minor version (=.+.0)
-     NON_BACKWARD_COMPATIBLE         - major version (+.0.0)
-     -->
-    <compat.level>BACKWARD_COMPATIBLE_USER</compat.level>
-    <compat.previous.version>2.10.3</compat.previous.version>
-    <api_check_oldVersion>2.10.3</api_check_oldVersion>
+    <api_check_oldVersion>2.10.4</api_check_oldVersion>
 
     <!-- 
      Configuring settings is best done through default properties that multiple plugins.
@@ -199,6 +192,4 @@
       </plugin>
     </plugins>
   </build>
-  
-  
 </project>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.11.0</version>
+  <version>2.11.1-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -230,7 +230,7 @@
   </build>
 
   <scm>
-    <tag>uimaj-2.11.0</tag>
+    <tag>HEAD</tag>
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -32,7 +32,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14-SNAPSHOT</version>
+    <version>14</version>
   </parent>
 
   <groupId>org.apache.uima</groupId>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -43,26 +43,6 @@
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the
-       same as those in super poms, it cannot be inherited because
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted.
-
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-parent
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-parent
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-parent
-    </url>
-  </scm>
-
   <!-- The repositories and pluginRepositories section is duplicated from
        the parent pom one, and adds the Apache Snapshot Nexus repository
        where UIMA snapshots are deployed.  This is needed if for instance,

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.10.5-SNAPSHOT</version>
+  <version>2.11.0</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -228,4 +228,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>uimaj-2.11.0</tag>
+  </scm>
 </project>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.11.0</version>
+  <version>2.11.1-SNAPSHOT</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -230,6 +230,9 @@
   </build>
 
   <scm>
-    <tag>uimaj-2.11.0</tag>
+    <tag>HEAD</tag>
+    <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
+    <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
+    <url>https://github.com/apache/uima-uimaj/</url>
   </scm>
 </project>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -38,7 +38,7 @@
   <groupId>org.apache.uima</groupId>
   <artifactId>uimaj-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.11.1-SNAPSHOT</version>
+  <version>2.11.0</version>
   <name>Apache UIMA Java SDK: ${project.artifactId}</name>
   <description>The common parent pom for the UIMA Java SDK</description>
   <url>${uimaWebsiteUrl}</url>
@@ -230,7 +230,7 @@
   </build>
 
   <scm>
-    <tag>HEAD</tag>
+    <tag>uimaj-2.11.0</tag>
     <connection>scm:git:https://github.com/apache/uima-uimaj/</connection>
     <developerConnection>scm:git:https://github.com/apache/uima-uimaj/</developerConnection>
     <url>https://github.com/apache/uima-uimaj/</url>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -34,26 +34,6 @@
   <description>Utilities for testing UIMA</description>
   <url>${uimaWebsiteUrl}</url>
 
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jvinci
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/jvinci
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/jvinci
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>jvinci</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimaj-parent</artifactId>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.11.0</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
   

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -33,26 +33,6 @@
   <description>Tooling supporting UIMA use</description>
   <url>${uimaWebsiteUrl}</url>
   
-  <!-- Special inheritance note
-       even though the <scm> element that follows is exactly the 
-       same as those in super poms, it cannot be inherited because 
-       there is some special code that computes the connection elements
-       from the chain of parent poms, if this is omitted. 
-       
-       Keeping this a bit factored allows cutting/pasting the <scm>
-       element, and just changing the following two properties -->  
-  <scm>
-    <connection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-tools
-    </connection>
-    <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-tools
-    </developerConnection>
-    <url>
-      https://github.com/apache/uima-uimaj/tree/master-v2/uimaj-tools
-    </url>
-  </scm>
-  
   <properties>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <postNoticeText>${ibmNoticeText}</postNoticeText>


### PR DESCRIPTION
**Jira**: https://issues.apache.org/jira/browse/UIMA-6328

- Update README file for release
- Update RELEASE_NOTES.html for release
- Removed commened out lines from aggregate-uimaj
- Fixed broken link in api-change-report.html
- Update Jira version in pom.xml
- Comment out SNAPSHOT repository
- Depend on UIMA Parent POM 14