### PR TITLE
[UIMA-6348] Race-condition in TypeSystemImpl commit

### DIFF
--- a/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
+++ b/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
@@ -58,16 +58,17 @@ Existing type systems, if found, are reused.
 Besides saving storage, this can sometimes improve locality of reference, and therefore, performance.
 Setting this property disables this consolidation.
 
-Disable strict type source checking
+Enable strict type source checking
 |
 
-`uima.disable_strict_type_source_check`
+`uima.enable_strict_type_source_check`
 
-Default: the type system a type belongs to must be exactly the type system instance of the CAS it is created in or added to.
+Default: checking whether the type actually belongs to the index/CAS is performed but only logs a warning, no exception.
 
 When creating a new feature structure or when adding or removing a feature structure to/from an index, it is checked that the
 type system the type belongs to is exactly the same instance as the type system of the CAS it is created in or the index it
-is added to. Due to the type system consolidation feature, this should always be the case. Setting this property disables the check.
+is added to. Due to the type system consolidation feature, this should always be the case. Setting this property causes an
+exception to be thrown - otherwise a warning is logged.
 
 |
 

--- a/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
+++ b/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
@@ -58,6 +58,17 @@ Existing type systems, if found, are reused.
 Besides saving storage, this can sometimes improve locality of reference, and therefore, performance.
 Setting this property disables this consolidation.
 
+Disable strict type source checking
+|
+
+`uima.disable_strict_type_source_check`
+
+Default: the type system a type belongs to must be exactly the type system instance of the CAS it is created in or added to.
+
+When creating a new feature structure or when adding or removing a feature structure to/from an index, it is checked that the
+type system the type belongs to is exactly the same instance as the type system of the CAS it is created in or the index it
+is added to. Due to the type system consolidation feature, this should always be the case. Setting this property disables the check.
+
 |
 
 Disable subtype of FSArray creation

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -1409,6 +1409,8 @@ public class CASImpl extends AbstractCas_ImplBase implements CAS, CASMgr, LowLev
                      // must happen before the annotation is created, for compressed form 6 serialization order
                      // to insure sofa precedes the ref of it
     }
+    
+    assertTypeBelongsToCasTypesystem(ti);
 
     FsGenerator3 g = svd.generators[ti.getCode()];  // get generator or null
     
@@ -1433,6 +1435,14 @@ public class CASImpl extends AbstractCas_ImplBase implements CAS, CASMgr, LowLev
 //    return (T) createFsFromGenerator(svd.generators, ti);
   }
   
+  private void assertTypeBelongsToCasTypesystem(TypeImpl ti) {
+    if (!TypeSystemImpl.IS_DISABLE_STRICT_TYPE_SOURCE_CHECK && tsi_local != null && ti.getTypeSystem() != tsi_local) {
+      throw new IllegalArgumentException("Cannot create feature structure of type [" + ti.getName()
+              + "](" + ti.getCode() + ") from type system [" + ti.getTypeSystem()
+              + "] in CAS with typesystem [" + tsi_local + "]");
+    }
+  }
+  
   /**
    * Called during construction of FS.
    * For normal FS "new" operators, if in PEAR context, make the base version
@@ -1451,6 +1461,7 @@ public class CASImpl extends AbstractCas_ImplBase implements CAS, CASMgr, LowLev
     TOP baseFs;
     try {
       suspendPearContext();
+      assertTypeBelongsToCasTypesystem(ti);
       svd.reuseId = fs._id;
       baseFs = createFsFromGenerator(svd.baseGenerators, ti);
     } finally {
@@ -5633,6 +5644,8 @@ public BooleanArray emptyBooleanArray() {
       case Slot_Short:
       case Slot_Int: return Integer.toString(iv);
       case Slot_Float: return Float.toString(int2float(iv));
+      default:
+        // Ignore
       }
     }
     if (v instanceof Long) {

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_bag.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_bag.java
@@ -85,6 +85,7 @@ public class FsIndex_bag<T extends FeatureStructure> extends FsIndex_singletype<
 
   @Override
   public final void insert(T fs) {
+    assertFsTypeMatchesIndexType(fs, "insert");
     maybeCopy();
     index.add((TOP) fs);
   }
@@ -180,6 +181,7 @@ public class FsIndex_bag<T extends FeatureStructure> extends FsIndex_singletype<
    */
   @Override
   public boolean deleteFS(T fs) {
+    assertFsTypeMatchesIndexType(fs, "deleteFS");
     maybeCopy();
     return this.index.remove(fs);
   }

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_set_sorted.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_set_sorted.java
@@ -89,7 +89,7 @@ final public class FsIndex_set_sorted<T extends FeatureStructure> extends FsInde
    */
   @Override
   void insert(T fs) {
-    
+    assertFsTypeMatchesIndexType(fs, "insert");
     // past the initial load, or item is not > previous largest item to be added 
     maybeCopy();
     if (isAnnotIdx) {
@@ -206,11 +206,7 @@ final public class FsIndex_set_sorted<T extends FeatureStructure> extends FsInde
    */
   @Override
   public boolean deleteFS(T fs) {
-    if (((TOP)fs)._getTypeImpl() != this.type) {
-      throw new IllegalArgumentException(
-          String.format("Wrong type %s passed to deleteFS of index over type %s", 
-            ((TOP)fs)._getTypeImpl().getName(), this.type.getName()));
-    }
+    assertFsTypeMatchesIndexType(fs, "deleteFS");
 //    maybeProcessBulkAdds(); // moved to OrderedFsSet_array class
     maybeCopy();
     return this.indexedFSs.remove(fs);

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_singletype.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIndex_singletype.java
@@ -586,7 +586,13 @@ public abstract class FsIndex_singletype<T extends FeatureStructure>
   @Override
   public abstract int compare(FeatureStructure o1, FeatureStructure o2);
   
-  
+  protected final void assertFsTypeMatchesIndexType(FeatureStructure fs, String operation) {
+    if (!TypeSystemImpl.IS_DISABLE_STRICT_TYPE_SOURCE_CHECK && ((TOP)fs)._getTypeImpl() != this.type) {
+      throw new IllegalArgumentException(
+          String.format("Wrong type %s passed to %s of index over type %s", 
+            ((TOP)fs)._getTypeImpl().getName(), operation, this.type.getName()));
+    }
+  }
 
   /// **
   // * Common part of iterator creation

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
@@ -144,13 +144,13 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
   public static final String DISABLE_TYPESYSTEM_CONSOLIDATION = "uima.disable_typesystem_consolidation";
 
   /**
-   * Define this JVM property to disable strictly checking the source of a type with respect to its
+   * Define this JVM property to enable strictly checking the source of a type with respect to its
    * type system. Normally (i.e. when typesystem consolidation is enabled), types that are semantically
    * equivalent should come from the same type system instances. There could be bugs (in client or framework
    * code) or legacy code which simply ignores this requirement and still works. Therefore, this property
    * allow to restore the old non-strict-checking behavior.
    */
-  public static final String DISABLE_STRICT_TYPE_SOURCE_CHECK = "uima.disable_strict_type_source_check";
+  public static final String ENABLE_STRICT_TYPE_SOURCE_CHECK = "uima.enable_strict_type_source_check";
 
   /**
    * public for test case
@@ -158,8 +158,8 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
   public static final boolean IS_DISABLE_TYPESYSTEM_CONSOLIDATION = // true || // debug
       Misc.getNoValueSystemProperty(DISABLE_TYPESYSTEM_CONSOLIDATION);
 
-  public static final boolean IS_DISABLE_STRICT_TYPE_SOURCE_CHECK = // true || // debug
-          Misc.getNoValueSystemProperty(DISABLE_STRICT_TYPE_SOURCE_CHECK);
+  public static final boolean IS_ENABLE_STRICT_TYPE_SOURCE_CHECK = // true || // debug
+          Misc.getNoValueSystemProperty(ENABLE_STRICT_TYPE_SOURCE_CHECK);
 
 //  private final static String DECOMPILE_JCAS = "uima.decompile.jcas";
 //  private final static boolean IS_DECOMPILE_JCAS = Misc.getNoValueSystemProperty(DECOMPILE_JCAS);

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSIndexTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSIndexTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.impl;
+
+import static org.apache.uima.UIMAFramework.getResourceSpecifierFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.Test;
+
+public class FSIndexTest {
+
+//  static {
+//    System.setProperty(TypeSystemImpl.ENABLE_STRICT_TYPE_SOURCE_CHECK, "true");
+//  }
+  
+  @Test
+  public void thatTypeSystemChangesCanBeHandled() throws Exception {
+
+    String myTypeName = "my.MyType";
+
+    TypeSystemDescription tsd1 = getResourceSpecifierFactory().createTypeSystemDescription();
+    tsd1.addType(myTypeName, "", CAS.TYPE_NAME_ANNOTATION);
+    tsd1.addType("some.OtherType1", "", CAS.TYPE_NAME_ANNOTATION);
+
+    TypeSystemDescription tsd2 = getResourceSpecifierFactory().createTypeSystemDescription();
+    tsd2.addType(myTypeName, "", CAS.TYPE_NAME_ANNOTATION);
+    tsd2.addType("some.OtherType2", "", CAS.TYPE_NAME_ANNOTATION);
+
+    CAS cas1 = CasCreationUtils.createCas(tsd1, null, null, null);
+    CAS cas2 = CasCreationUtils.createCas(tsd2, null, null, null);
+
+    assertThat(cas1.getTypeSystem())
+            .as("There exists two CASes in the JVM which have different type systems "
+                    + "containing the same internal and exteral types")
+            .isNotEqualTo(cas2.getTypeSystem());
+
+    assertThat(cas1.getTypeSystem().getType(myTypeName))
+            .as("The internal type is the same in both type systems")
+            .isEqualTo(cas2.getTypeSystem().getType(myTypeName));
+
+    Type myTypeFromCas2 = getType(cas2, myTypeName);
+
+    List<String> capturedOutput = captureOutput(() -> {
+      AnnotationFS brokenFs = cas1.createAnnotation(myTypeFromCas2, 0, 0);
+      cas1.addFsToIndexes(brokenFs);
+      return null;
+    });
+
+    assertThat(capturedOutput.get(0)).contains("in CAS with different type system");
+    assertThat(capturedOutput.get(1)).contains("on index using different type system");
+  }
+
+  private List<String> captureOutput(Callable<Void> code) throws Exception {
+    org.apache.logging.log4j.core.Logger rootLogger = (org.apache.logging.log4j.core.Logger) org.apache.logging.log4j.LogManager
+            .getRootLogger();
+
+    List<String> messages = new ArrayList<>();
+
+    Filter filter = new AbstractFilter() {
+      @Override
+      public Result filter(LogEvent event) {
+        messages.add(event.getMessage().getFormattedMessage());
+        return Result.ACCEPT;
+      }
+    };
+
+    ConsoleAppender app = (ConsoleAppender) rootLogger.get().getAppenders().values().stream()
+            .findFirst().get();
+    app.addFilter(filter);
+
+    try {
+      code.call();
+      return messages;
+    } finally {
+      app.removeFilter(filter);
+    }
+  }
+
+  private Type getType(CAS cas, String typename) {
+    return cas.getTypeSystem().getType(typename);
+  }
+}


### PR DESCRIPTION
- Perform the check if a type matches the expected type system not only in FsIndex_set_sorted.deleteFS but also in other deleteFS and insert methods
- Extract the check into a separate method
- Also perform the check when creating a feature structure via the CAS
- Added and documented option to disable strict checking