### PR TITLE
UIMA-6349: japicmp post processing script fails with Java 16

### DIFF
--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -206,9 +206,23 @@
   <build>
     <plugins>
       <plugin>
+        <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.15.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>2.5.14</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      
+      <plugin>
         <groupId>org.openntf.maven</groupId>
         <artifactId>p2-layout-resolver</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
         <extensions>true</extensions>
       </plugin>
     


### PR DESCRIPTION
- Upgrade japicmp / groovy to be compatible with Java 16
- Also bump p2-layout-resolver to be compatible with Java 16

(cherry picked from commit a60114e837f445db8bacc5049be9f46259b53eb6)