### PR TITLE
[UIMA-6352] reinit(CASCompleteSerializer) does not properly reset indexes

### DIFF
--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -332,7 +332,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-          <!-- set the heap using the property maven.surefire.heap -->
+          <systemProperties>
+            <uima.enable_strict_type_source_check>true</uima.enable_strict_type_source_check>
+          </systemProperties>
           <!--  include dependencies that are for logging but specified as "provided" -->
           <additionalClasspathElements>
             <additionalClasspathElement>${settings.localRepository}/org/apache/logging/log4j/log4j-core/${log4j.version}/log4j-core-${log4j.version}.jar</additionalClasspathElement>

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes.java
@@ -267,6 +267,7 @@ public class BinaryCasSerDes {
     if (null != casMgrSerializer) {
   
       TypeSystemImpl ts = casMgrSerializer.getTypeSystem();
+      baseCas.svd.clear();  // does all clearing except index repositories which will be wiped out   
       baseCas.installTypeSystemInAllViews(ts);
       baseCas.commitTypeSystem();
   

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes.java
@@ -297,32 +297,7 @@ public class BinaryCasSerDes {
    * @param casCompSer -
    */
   public void reinit(CASCompleteSerializer casCompSer) {
-    TypeSystemImpl ts = casCompSer.getCASMgrSerializer().getTypeSystem();
-    
-    /*
-     * Special clearing:
-     *   Skips the resetNoQuestions operation of flushing the indexes, 
-     *   since these will be reinitialized with potentially new definitions.
-     *   
-     *   Clears additional data related to having the
-     *   - type system potentially change
-     *   - the features belonging to indexes change
-     */
-    baseCas.svd.clear();  // does all clearing except index repositories which will be wiped out   
-    baseCas.installTypeSystemInAllViews(ts);  // the commit (next) re-installs it if it changes
-    baseCas.commitTypeSystem();
-
-    // reset index repositories -- wipes out Sofa index
-    casCompSer.getCASMgrSerializer().getIndexRepository(baseCas);  // sets the argument's index repository
-    baseCas.indexRepository.commit();
-
-    // get handle to existing initial View
-    CASImpl initialView = (CASImpl) baseCas.getInitialView();
-
-    // freshen the initial view
-    initialView.refreshView(baseCas, null);  // sets jcas to null for the view, too
-    baseCas.svd.setViewForSofaNbr(1, initialView);
-    baseCas.svd.viewCount = 1;
+    setupCasFromCasMgrSerializer(casCompSer.getCASMgrSerializer());
 
     // deserialize heap
     CASSerializer casSer = casCompSer.getCASSerializer();

--- a/uimaj-core/src/test/java/org/apache/uima/cas/test/CompleteSerializationTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/test/CompleteSerializationTest.java
@@ -16,156 +16,133 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.uima.cas.test;
+
+import static org.apache.uima.cas.impl.Serialization.deserializeCASComplete;
+import static org.apache.uima.cas.impl.Serialization.serializeCASComplete;
+import static org.apache.uima.cas.impl.Serialization.serializeWithCompression;
+import static org.apache.uima.util.CasCreationUtils.createCas;
+import static org.apache.uima.util.CasIOUtils.load;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
+import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.admin.CASMgr;
 import org.apache.uima.cas.impl.CASCompleteSerializer;
 import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.cas.impl.CasCompare;
 import org.apache.uima.cas.impl.LowLevelCAS;
-import org.apache.uima.cas.impl.LowLevelException;
 import org.apache.uima.cas.impl.Serialization;
-import org.apache.uima.internal.util.Int2ObjHashMap;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.cas.FSArray;
-import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
-import org.apache.uima.test.junit_extension.JUnitExtension;
 import org.apache.uima.util.AutoCloseableNoException;
 import org.apache.uima.util.CasCreationUtils;
-
-import junit.framework.TestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * CAS complete serialization test class
- * 
  */
-public class CompleteSerializationTest extends TestCase {
+public class CompleteSerializationTest {
 
-  /**
-   * Constructor for CASTest.
-   * 
-   * @param arg0
-   */
-  public CompleteSerializationTest(String arg0) {
-    super(arg0);
+  @BeforeClass
+  public static void setupClass() {
+    System.setProperty("uima.enable_strict_type_source_check", "true");
   }
 
+  @AfterClass
+  public static void tearDownClass() {
+    System.getProperties().remove("uima.enable_strict_type_source_check");
+  }
+
+  @Test
   public void testSerialization() throws Exception {
-    try {
-      CASMgr cas = null;
-      try {
-        cas = (CASMgr) CASInitializer.initCas(new CASTestSetup(), null);
-      } catch (Exception e) {
-        assertTrue(false);
-      }
-      ((CAS) cas).setDocumentText("Create the sofa for the inital view");
-      assertTrue(((CASImpl) cas).isBackwardCompatibleCas());
-      CASCompleteSerializer ser = Serialization.serializeCASComplete(cas);
+    CASMgr cas = (CASMgr) CASInitializer.initCas(new CASTestSetup(), null);
 
-      // deserialize into a new CAS with a type system that only contains the builtins
-      CAS newCas = CasCreationUtils.createCas(new TypeSystemDescription_impl(), null, null);
+    ((CAS) cas).setDocumentText("Create the sofa for the inital view");
+    assertTrue(((CASImpl) cas).isBackwardCompatibleCas());
+    CASCompleteSerializer ser = Serialization.serializeCASComplete(cas);
 
-      try {
-        Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
-      } catch (Exception e) {
-        assertTrue(false);
-      }
-      assertTrue(((CASImpl) newCas).getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
-      assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
-      assertEquals("Create the sofa for the inital view", newCas.getDocumentText());
+    // deserialize into a new CAS with a type system that only contains the builtins
+    CAS newCas = CasCreationUtils.createCas(new TypeSystemDescription_impl(), null, null);
 
-      // make sure JCas can be created
-      newCas.getJCas();
+    Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
 
-      // deserialize into newCas a second time (OF bug found 7/7/2006)
-      try {
-        Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
-      } catch (Exception e) {
-        assertTrue(false);
-      }
-      assertTrue(cas.getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
-      assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
-      boolean caught = false;
-      try {
-      ((LowLevelCAS)newCas).ll_enableV2IdRefs();
-      } catch (IllegalStateException e) {
-        caught = true;
-      }
-      assertTrue(caught);
-    } catch (Exception e) {
-      JUnitExtension.handleException(e);
-    }
-    
+    assertTrue(((CASImpl) newCas).getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
+    assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
+    assertEquals("Create the sofa for the inital view", newCas.getDocumentText());
 
+    // make sure JCas can be created
+    newCas.getJCas();
+
+    // deserialize into newCas a second time (OF bug found 7/7/2006)
+    Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
+
+    assertTrue(cas.getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
+    assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
+
+    assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> ((LowLevelCAS) newCas).ll_enableV2IdRefs());
   }
 
+  @Test
   public void testSerializationV2IdRefs() throws Exception {
-    try (AutoCloseableNoException a = LowLevelCAS.ll_defaultV2IdRefs()){
-      CAS cas = null;
-      JCas jcas = null;
-      
-      try {
-        cas =  CASInitializer.initCas(new CASTestSetup(), null);
-        jcas = cas.getJCas();
-      } catch (Exception e) {
-        assertTrue(false);
-      }
+    try (AutoCloseableNoException a = LowLevelCAS.ll_defaultV2IdRefs()) {
+      CAS cas = CASInitializer.initCas(new CASTestSetup(), null);
+      JCas jcas = cas.getJCas();
+
       cas.setDocumentText("Create the sofa for the inital view");
       assertTrue(((CASImpl) cas).isBackwardCompatibleCas());
-      
+
       Type t1 = cas.getTypeSystem().getType(CASTestSetup.ARRAYFSWITHSUBTYPE_TYPE);
       Feature feat1 = t1.getFeatureByBaseName(CASTestSetup.ARRAYFSWITHSUBTYPE_TYPE_FEAT);
-
 
       FSArray<FeatureStructure> fsa1 = new FSArray<>(jcas, 1);
       FeatureStructure f1 = cas.createFS(t1);
       f1.setFeatureValue(feat1, fsa1);
 
       Annotation myAnnot = new Annotation(jcas);
-      
+
       fsa1.set(0, myAnnot);
 
       myAnnot = new Annotation(jcas);
       int id = myAnnot._id();
       myAnnot = new Annotation(jcas);
       int id2 = myAnnot._id();
-      assertEquals(4, id2 - id);  // type code, sofa, begin, end
-            
-      CASCompleteSerializer ser = Serialization.serializeCASComplete((CASMgr)cas);
+      assertEquals(4, id2 - id); // type code, sofa, begin, end
+
+      CASCompleteSerializer ser = Serialization.serializeCASComplete((CASMgr) cas);
 
       // deserialize into a new CAS with a type system that only contains the builtins
       CAS newCas = CasCreationUtils.createCas(new TypeSystemDescription_impl(), null, null);
 
-      try {
         Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
-      } catch (Exception e) {
-        assertTrue(false);
-      }      
-      LowLevelCAS ll = newCas.getLowLevelCAS();
-      boolean caught = false;
-      try {
-      assertEquals(id, ll.ll_getFSForRef(id)._id());
-      } catch (LowLevelException e ) {
-        caught = true;
-      }
-      assertFalse(caught);
       
-      CasCompare cc = new CasCompare((CASImpl)cas,  (CASImpl)newCas);
+      LowLevelCAS ll = newCas.getLowLevelCAS();
+      
+      assertEquals(id, ll.ll_getFSForRef(id)._id());
+      
+      CasCompare cc = new CasCompare((CASImpl) cas, (CASImpl) newCas);
       cc.compareIds(true);
       assertTrue(cc.compareCASes());
-      
-      Serialization.deserializeCASComplete(ser, (CASImpl) newCas);     
+
+      Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
       assertEquals(id, ll.ll_getFSForRef(id)._id());
-      assertEquals(id2, ll.ll_getFSForRef(id2)._id());        
-      
-      assertEquals(id2, ll.ll_getFSForRef(id2)._id());        
+      assertEquals(id2, ll.ll_getFSForRef(id2)._id());
+
+      assertEquals(id2, ll.ll_getFSForRef(id2)._id());
       assertTrue(((CASImpl) newCas).getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
       assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
       assertEquals("Create the sofa for the inital view", newCas.getDocumentText());
@@ -174,16 +151,36 @@ public class CompleteSerializationTest extends TestCase {
       newCas.getJCas();
 
       // deserialize into newCas a second time (OF bug found 7/7/2006)
-      try {
-        Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
-      } catch (Exception e) {
-        assertTrue(false);
-      }
-      assertTrue(((CASMgr)cas).getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
+      Serialization.deserializeCASComplete(ser, (CASImpl) newCas);
+      
+      assertTrue(((CASMgr) cas).getTypeSystemMgr().getType(CASTestSetup.GROUP_1) != null);
       assertTrue(((CASImpl) newCas).isBackwardCompatibleCas());
-    } catch (Exception e) {
-      JUnitExtension.handleException(e);
     }
   }
+  
+  @Test
+  public void thatReplacingTypeSystemInCasWorks() throws Exception {
+    // Construct a CAS with two views
+    CAS cas = CasCreationUtils.createCas();
+    cas.setDocumentText("First view text");
+    cas.createView("secondView").setDocumentText("Second view text");
 
+    // Save the CAS data to a buffer
+    TypeSystem originalTypeSystem = cas.getTypeSystem();
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    serializeWithCompression(cas, buffer, originalTypeSystem);
+    
+    // Create a new type system
+    TypeSystemDescription newTSD = new TypeSystemDescription_impl();
+    newTSD.addType("my.Type", "", CAS.TYPE_NAME_ANNOTATION);
+    
+    // Replace the type system in the CAS with the new type system
+    CAS tempCas = createCas(newTSD, null, null, null);
+    CASCompleteSerializer serializer = serializeCASComplete((CASImpl) tempCas);
+    deserializeCASComplete(serializer, (CASImpl) cas);
+    
+    // Write the CAS data from the buffer back into the CAS - this throws an exception if the
+    // FSIndexRepositories are not properly reset (cf. UIMA-6352)
+    load(new ByteArrayInputStream(buffer.toByteArray()), cas, originalTypeSystem);
+  }
 }


### PR DESCRIPTION
- Fixed issue by calling setupCasFromCasMgrSerializer in reinit(CASCompleteSerializer) instead of using incomplete custom code
- Added unit test
- More thorough cleaning up in setupCasFromCasMgrSerializer()
- Adjusted FSIndexTest so it runs also when "uima.enable_strict_type_source_check" is enabled
- Enable "uima.enable_strict_type_source_check" for Maven surefire builds