### PR TITLE
[UIMA-6305] Convert UIMAv3 User's Guide from DocBook to Asciidoc

### DIFF
--- a/src/main/assembly/bin-without-jackson.xml
+++ b/src/main/assembly/bin-without-jackson.xml
@@ -275,7 +275,7 @@ under the License.
       <directoryMode>755</directoryMode>        
     </fileSet>
     <fileSet>
-      <directory>uima-docbook-v3-users-guide/target/site</directory>
+      <directory>uima-doc-v3-users-guide/target/site</directory>
       <outputDirectory>docs</outputDirectory>
       <fileMode>644</fileMode>
       <directoryMode>755</directoryMode>        

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -288,7 +288,7 @@ under the License.
       <directoryMode>755</directoryMode>        
     </fileSet>
     <fileSet>
-      <directory>uima-docbook-v3-users-guide/target/site</directory>
+      <directory>uima-doc-v3-users-guide/target/site</directory>
       <outputDirectory>docs</outputDirectory>
       <fileMode>644</fileMode>
       <directoryMode>755</directoryMode>        

--- a/uima-doc-v3-users-guide/pom.xml
+++ b/uima-doc-v3-users-guide/pom.xml
@@ -44,13 +44,13 @@
     element, and just changing the following two properties -->
   <scm>
     <connection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-v3-users-guide
+      scm:git:https://github.com/apache/uima-uimaj/uima-doc-v3-users-guide
     </connection>
     <developerConnection>
-      scm:git:https://github.com/apache/uima-uimaj/uima-docbook-v3-users-guide
+      scm:git:https://github.com/apache/uima-uimaj/uima-doc-v3-users-guide
     </developerConnection>
     <url>
-      https://github.com/apache/uima-uimaj/tree/master/uima-docbook-v3-users-guide
+      https://github.com/apache/uima-uimaj/tree/master/uima-doc-v3-users-guide
     </url>
     <tag>HEAD</tag>
   </scm>

--- a/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
+++ b/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.migration.aids.adoc
@@ -58,6 +58,8 @@ Existing type systems, if found, are reused.
 Besides saving storage, this can sometimes improve locality of reference, and therefore, performance.
 Setting this property disables this consolidation.
 
+| 
+
 Enable strict type source checking
 |
 
@@ -116,8 +118,16 @@ This property sets the default value, per CAS, for that CAS's `ll_enableV2IdRefs
 This mode is is also programmatically settable, which overrides this default.
 
 For more details on how this setting operates and interacts with the associated APIs, <<_uv3.backwards_compatibility.preserve_v2_ids>>
+|===
 
-|**Trading off runtime checks for speed**
+
+== Trading off runtime checks for speed
+
+[cols="1,1", frame="all"]
+|===
+
+|**Title**
+|**Property Name & Description**
 
 |
 
@@ -138,8 +148,16 @@ Disabling runtime feature _value_ validation
 Default: features being set into FS features which are FSs are checked for proper type subsumption.
 
 Once code is running correctly, you may remove this check for performance reasons by setting this property.
+|===
 
-|**Reporting**
+
+== Reporting
+
+[cols="1,1", frame="all"]
+|===
+
+|**Title**
+|**Property Name & Description**
 
 |
 


### PR DESCRIPTION
- Adjust assemblies to include the "doc-v3" instead of the "docbook-v3"
- Fix properties table