### PR TITLE
UIMA-6367: JCas cover annotation created in PEAR context replaced during index operations

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -1483,6 +1483,7 @@ public class CASImpl extends AbstractCas_ImplBase implements CAS, CASMgr, LowLev
       svd.reuseId = 0;
     }
     svd.id2base.put(baseFs);
+    svd.id2tramp.put(baseFs._id, (TOP) fs);
     pearBaseFs = baseFs;
     return true;
   }

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -889,6 +889,15 @@ public class CASImpl extends AbstractCas_ImplBase implements CAS, CASMgr, LowLev
       if (null == newClassLoader) { // is null if no cl set
         return;
       }
+      
+      if (!(newClassLoader instanceof UIMAClassLoader)) {
+        UIMAFramework.getLogger()
+                .debug("Calling switchClassLoader with a classloader of type [{}] that is not "
+                        + "a UIMAClassLoader may cause JCas wrappers to be loaded from the wrong "
+                        + "classloader.",
+                        newClassLoader.getClass().getName());
+      }
+      
       if (newClassLoader != jcasClassLoader) {
         if (null != previousJCasClassLoader) {
           /** Multiply nested classloaders not supported.  Original base loader: {0}, current nested loader: {1}, trying to switch to loader: {2}.*/
@@ -5217,6 +5226,7 @@ public FloatArray emptyFloatArray() {
     return emptyFSArray(null);
   }
   
+  @Override
   public <T extends FeatureStructure> FSArray<T> emptyFSArray(Type type) {
     return svd.emptyFSArrayMap.computeIfAbsent(type, t -> (t == null) 
         ? new FSArray(this.getJCas(), 0)

--- a/uimaj-core/src/main/java/org/apache/uima/jcas/impl/JCasHashMapSubMap.java
+++ b/uimaj-core/src/main/java/org/apache/uima/jcas/impl/JCasHashMapSubMap.java
@@ -344,21 +344,22 @@ class JCasHashMapSubMap implements Iterable<TOP> {
       
      // may recursively invoke this method, may throw exception
       m = creatorFromKey.apply(key);
-      
+     
   //    System.out.println("debug waiting to reacquire lock after creator." + Thread.currentThread().getName());
 //      lockit();
   //    System.out.println("debug after reacquire lock after creator." + Thread.currentThread().getName());
       
       if (localTable == table) {
-        
-        assert table[saved_reserved_index] == reserve;
+        // UIMA-6367 we maybe already set it in constructor
+        assert table[saved_reserved_index] == reserve || table[saved_reserved_index] == m;
         table[saved_reserved_index] = m;
 //        debugcheck(saved_reserved_index);
         
       } else {
         resetProbeInfo(probeInfo);
         TOP r = find(table, key, hash, probeInfo);
-        assert isReserve(r);
+        // UIMA-6367 we maybe already set it in constructor
+        assert isReserve(r) || r == m;
 //        assert r == null;
 //        assert r._id() == key;
         table[probeInfo[PROBE_ADDR_INDEX]] = m;  // set real value

--- a/uimaj-core/src/test/java/org/apache/uima/cas/test/FSCreatedInPearContextTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/test/FSCreatedInPearContextTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.test;
+
+import static org.apache.uima.UIMAFramework.getXMLParser;
+import static org.apache.uima.UIMAFramework.newDefaultResourceManager;
+import static org.apache.uima.util.CasCreationUtils.createCas;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.test.JCasClassLoaderTest.IsolatingClassloader;
+import org.apache.uima.cas.test.JCasClassLoaderTest.JCasCreator;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.ResourceManager;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.InvalidXMLException;
+import org.apache.uima.util.XMLInputSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FSCreatedInPearContextTest {
+
+  @Test
+  public void thatAnnotationIsCreatedOnce() throws Exception, IOException {
+
+    ClassLoader rootCl = getClass().getClassLoader();
+
+    IsolatingClassloader clForCas = new IsolatingClassloader("CAS", rootCl);
+
+    ClassLoader clForToken = new IsolatingClassloader("Token", rootCl)
+            .redefining("org\\.apache\\.uima\\.cas\\.test\\.Token(_Type)?.*");
+    
+    TypeSystemDescription tsd = loadTokensAndSentencesTS();
+    
+    JCas jcas = makeJCas(clForCas, tsd);
+    jcas.setDocumentText("Test");
+
+    CASImpl casImpl = jcas.getCasImpl();
+    casImpl.switchClassLoader(clForToken, false);
+    
+    Annotation mockedPearToken = createToken(jcas, clForToken);
+    
+    Annotation indexedToken = jcas.getAnnotationIndex(Token.class).iterator().next();
+
+    Assert.assertTrue("Token identical", mockedPearToken == indexedToken);
+  }
+
+  private Annotation createToken(JCas jcas, ClassLoader clForToken) throws Exception {
+    Class<?> tokenClass = clForToken.loadClass(Token.class.getName());
+    Constructor<?> constructor = tokenClass.getConstructor(JCas.class);
+    Annotation token = (Annotation) constructor.newInstance(jcas);
+    token.addToIndexes();
+    return token;
+  }
+
+  private TypeSystemDescription loadTokensAndSentencesTS() throws InvalidXMLException, IOException {
+    return getXMLParser().parseTypeSystemDescription(new XMLInputSource(
+            new File("src/test/resources/CASTests/desc/TokensAndSentencesTS.xml")));
+  }
+
+  private JCas makeJCas(IsolatingClassloader cl, TypeSystemDescription tsd)
+          throws Exception {
+    cl.redefining("^.*JCasCreatorImpl$");
+    Class<?> jcasCreatorClass = cl.loadClass(SimpleJCasCreatorImpl.class.getName());
+    JCasCreator creator = (JCasCreator) jcasCreatorClass.newInstance();
+    return creator.createJCas(cl, tsd);
+  }
+  
+  public static class SimpleJCasCreatorImpl implements JCasCreator {
+
+    @Override
+    public JCas createJCas(ClassLoader cl, TypeSystemDescription tsd)
+    {
+      try {
+        ResourceManager resMgr = newDefaultResourceManager();
+        resMgr.setExtensionClassLoader(cl, false);
+        CASImpl cas = (CASImpl) createCas(tsd, null, null, null, resMgr);
+        cas.setJCasClassLoader(cl);
+        return cas.getJCas();
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+  
+}

--- a/uimaj-core/src/test/java/org/apache/uima/cas/test/FSCreatedInPearContextTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/test/FSCreatedInPearContextTest.java
@@ -19,89 +19,59 @@
 package org.apache.uima.cas.test;
 
 import static org.apache.uima.UIMAFramework.getXMLParser;
-import static org.apache.uima.UIMAFramework.newDefaultResourceManager;
 import static org.apache.uima.util.CasCreationUtils.createCas;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-
+import java.net.URL;
+import org.apache.uima.cas.Type;
 import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.cas.test.JCasClassLoaderTest.IsolatingClassloader;
-import org.apache.uima.cas.test.JCasClassLoaderTest.JCasCreator;
-import org.apache.uima.jcas.JCas;
+import org.apache.uima.internal.util.UIMAClassLoader;
 import org.apache.uima.jcas.tcas.Annotation;
-import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class FSCreatedInPearContextTest {
 
   @Test
-  public void thatAnnotationIsCreatedOnce() throws Exception, IOException {
+  public void thatOneTrampolineIsUsedWhenClassLoaderIsSwitched() throws Exception, IOException {
 
     ClassLoader rootCl = getClass().getClassLoader();
 
-    IsolatingClassloader clForCas = new IsolatingClassloader("CAS", rootCl);
-
-    ClassLoader clForToken = new IsolatingClassloader("Token", rootCl)
+    IsolatingClassloader clForToken = new IsolatingClassloader("Token", rootCl)
             .redefining("org\\.apache\\.uima\\.cas\\.test\\.Token(_Type)?.*");
-    
-    TypeSystemDescription tsd = loadTokensAndSentencesTS();
-    
-    JCas jcas = makeJCas(clForCas, tsd);
-    jcas.setDocumentText("Test");
 
-    CASImpl casImpl = jcas.getCasImpl();
-    casImpl.switchClassLoader(clForToken, false);
-    
-    Annotation mockedPearToken = createToken(jcas, clForToken);
-    
-    Annotation indexedToken = jcas.getAnnotationIndex(Token.class).iterator().next();
+    CASImpl casImpl = (CASImpl) createCas(loadTokensAndSentencesTS(), null, null, null);
+    casImpl.switchClassLoaderLockCasCL(new UIMAClassLoader(new URL[0], clForToken));
+    casImpl.setDocumentText("Test");
 
-    Assert.assertTrue("Token identical", mockedPearToken == indexedToken);
-  }
-
-  private Annotation createToken(JCas jcas, ClassLoader clForToken) throws Exception {
-    Class<?> tokenClass = clForToken.loadClass(Token.class.getName());
-    Constructor<?> constructor = tokenClass.getConstructor(JCas.class);
-    Annotation token = (Annotation) constructor.newInstance(jcas);
+    Type tokenType = casImpl.getTypeSystem().getType(Token.class.getName());
+    Annotation token = casImpl.createAnnotation(tokenType, 0, 1);
     token.addToIndexes();
-    return token;
+    assertThat(token.getClass().getClassLoader())
+            .as("Trampoline returned by createAnnotation after classloader switch")
+            .isSameAs(clForToken);
+
+    assertThat(casImpl.select(Token.type).asList()) //
+            .as("Same trampoline returned by [select(Token.type)] after classloader switch")
+            .usingElementComparator((a, b) -> a == b ? 0 : 1) //
+            .containsExactly(token)
+            .allMatch(t -> t.getClass().getClassLoader() == clForToken);
+
+    casImpl.restoreClassLoaderUnlockCas();
+    assertThat(casImpl.select(Token.type).asList()) //
+            .as("After switching back out of the the classloader context, we get the base FS")
+            .usingElementComparator((a, b) -> a._id() == b._id() ? 0 : 1) //
+            .containsExactly(token)
+            .allMatch(t -> t.getClass().getClassLoader() == rootCl);
   }
 
   private TypeSystemDescription loadTokensAndSentencesTS() throws InvalidXMLException, IOException {
     return getXMLParser().parseTypeSystemDescription(new XMLInputSource(
             new File("src/test/resources/CASTests/desc/TokensAndSentencesTS.xml")));
   }
-
-  private JCas makeJCas(IsolatingClassloader cl, TypeSystemDescription tsd)
-          throws Exception {
-    cl.redefining("^.*JCasCreatorImpl$");
-    Class<?> jcasCreatorClass = cl.loadClass(SimpleJCasCreatorImpl.class.getName());
-    JCasCreator creator = (JCasCreator) jcasCreatorClass.newInstance();
-    return creator.createJCas(cl, tsd);
-  }
-  
-  public static class SimpleJCasCreatorImpl implements JCasCreator {
-
-    @Override
-    public JCas createJCas(ClassLoader cl, TypeSystemDescription tsd)
-    {
-      try {
-        ResourceManager resMgr = newDefaultResourceManager();
-        resMgr.setExtensionClassLoader(cl, false);
-        CASImpl cas = (CASImpl) createCas(tsd, null, null, null, resMgr);
-        cas.setJCasClassLoader(cl);
-        return cas.getJCas();
-      }
-      catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-  
 }


### PR DESCRIPTION
- fixed trampoline map
- added test that checks annotation instance in mocked pear context