### PR TITLE
[UIMA-6374] Create CAS (de)serialization test suite

### DIFF
--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_BINARY_TSI_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_BINARY_TSI_Test.java
@@ -29,6 +29,8 @@ import static org.apache.uima.util.CasLoadMode.REINIT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -68,11 +70,13 @@ public class CasSerializationDeserialization_BINARY_TSI_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build(),
+            MultiTypeRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_BINARY_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_BINARY_Test.java
@@ -30,6 +30,8 @@ import static org.apache.uima.util.CasLoadMode.REINIT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -69,11 +71,13 @@ public class CasSerializationDeserialization_BINARY_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build(),
+            MultiTypeRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_COMPRESSED_FILTERED_TSI_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_COMPRESSED_FILTERED_TSI_Test.java
@@ -28,6 +28,8 @@ import static org.apache.uima.util.CasLoadMode.REINIT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -67,11 +69,13 @@ public class CasSerializationDeserialization_COMPRESSED_FILTERED_TSI_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build(),
+            MultiTypeRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_SERIALIZED_TSI_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_SERIALIZED_TSI_Test.java
@@ -28,6 +28,8 @@ import static org.apache.uima.util.CasLoadMode.REINIT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -67,11 +69,13 @@ public class CasSerializationDeserialization_SERIALIZED_TSI_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build(),
+            MultiTypeRandomCasDataSuite.builder().withIterations(RANDOM_CAS_ITERATIONS).build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XCAS_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XCAS_Test.java
@@ -24,6 +24,7 @@ import static org.apache.uima.cas.serdes.SerDesAssuptions.assumeNotKnownToFail;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.createCasMaybeWithTypesystem;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.desser;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.serdes;
+import static org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode.EMPTY_STRINGS_AS_NULL;
 import static org.apache.uima.util.CasCreationUtils.createCas;
 import static org.apache.uima.util.CasLoadMode.DEFAULT;
 import static org.apache.uima.util.CasLoadMode.LENIENT;
@@ -31,6 +32,8 @@ import static org.apache.uima.util.CasLoadMode.LENIENT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -70,11 +73,18 @@ public class CasSerializationDeserialization_XCAS_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .withStringArrayMode(EMPTY_STRINGS_AS_NULL) //
+                    .build(),
+            MultiTypeRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XMI_1_0_PRETTY_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XMI_1_0_PRETTY_Test.java
@@ -24,6 +24,7 @@ import static org.apache.uima.cas.serdes.SerDesAssuptions.assumeNotKnownToFail;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.desser;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.serdes;
 import static org.apache.uima.cas.serdes.datasuites.XmiFileDataSuite.DATA_XMI;
+import static org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode.NULL_STRINGS_AS_EMPTY;
 import static org.apache.uima.util.CasCreationUtils.createCas;
 import static org.apache.uima.util.CasLoadMode.DEFAULT;
 import static org.apache.uima.util.CasLoadMode.LENIENT;
@@ -31,6 +32,8 @@ import static org.apache.uima.util.CasLoadMode.LENIENT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -71,7 +74,7 @@ public class CasSerializationDeserialization_XMI_1_0_PRETTY_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   // private static List<DesSerTestScenario> desSerScenarios() {
@@ -102,7 +105,14 @@ public class CasSerializationDeserialization_XMI_1_0_PRETTY_Test {
   // }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .withStringArrayMode(NULL_STRINGS_AS_EMPTY) //
+                    .build(),
+            MultiTypeRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XMI_1_1_PRETTY_Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/CasSerializationDeserialization_XMI_1_1_PRETTY_Test.java
@@ -24,6 +24,7 @@ import static org.apache.uima.cas.serdes.SerDesAssuptions.assumeNotKnownToFail;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.desser;
 import static org.apache.uima.cas.serdes.SerDesCasIOTestUtils.serdes;
 import static org.apache.uima.cas.serdes.datasuites.XmiFileDataSuite.DATA_XMI;
+import static org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode.NULL_STRINGS_AS_EMPTY;
 import static org.apache.uima.util.CasCreationUtils.createCas;
 import static org.apache.uima.util.CasLoadMode.DEFAULT;
 import static org.apache.uima.util.CasLoadMode.LENIENT;
@@ -31,6 +32,8 @@ import static org.apache.uima.util.CasLoadMode.LENIENT;
 import java.util.List;
 
 import org.apache.uima.cas.SerialFormat;
+import org.apache.uima.cas.serdes.datasuites.MultiFeatureRandomCasDataSuite;
+import org.apache.uima.cas.serdes.datasuites.MultiTypeRandomCasDataSuite;
 import org.apache.uima.cas.serdes.scenario.DesSerTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerDesTestScenario;
 import org.apache.uima.cas.serdes.scenario.SerRefTestScenario;
@@ -70,11 +73,18 @@ public class CasSerializationDeserialization_XMI_1_1_PRETTY_Test {
   }
 
   private static List<SerDesTestScenario> serDesScenarios() {
-    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles);
+    return SerDesCasIOTestUtils.programmaticSerDesScenarios(serDesCycles);
   }
 
   private static List<SerDesTestScenario> randomSerDesScenarios() {
-    return SerDesCasIOTestUtils.randomSerDesScenarios(serDesCycles, RANDOM_CAS_ITERATIONS);
+    return SerDesCasIOTestUtils.serDesScenarios(serDesCycles,
+            MultiFeatureRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .withStringArrayMode(NULL_STRINGS_AS_EMPTY) //
+                    .build(),
+            MultiTypeRandomCasDataSuite.builder() //
+                    .withIterations(RANDOM_CAS_ITERATIONS) //
+                    .build());
   }
 
   @ParameterizedTest

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/CasDataSuite.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/CasDataSuite.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.serdes.datasuites;
+
+import java.util.Collection;
+
+import org.apache.uima.cas.serdes.transitions.CasSourceTargetConfiguration;
+
+public interface CasDataSuite extends Collection<CasSourceTargetConfiguration> {
+}

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/MultiFeatureRandomCasDataSuite.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/MultiFeatureRandomCasDataSuite.java
@@ -18,21 +18,37 @@
  */
 package org.apache.uima.cas.serdes.datasuites;
 
+import static org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode.ALLOW_NULL_AND_EMPTY_STRINGS;
+
+import java.util.AbstractCollection;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.uima.cas.serdes.generators.CasConfiguration;
 import org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator;
+import org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode;
 import org.apache.uima.cas.serdes.transitions.CasSourceTargetConfiguration;
 
-public class MultiFeatureRandomCasDataSuite {
+public class MultiFeatureRandomCasDataSuite extends AbstractCollection<CasSourceTargetConfiguration>
+        implements CasDataSuite {
+  private final int sizeFactor;
+  private final StringArrayMode stringArrayMode;
+  private final int iterations;
 
-  public static List<CasSourceTargetConfiguration> configurations(int aCount) {
+  private MultiFeatureRandomCasDataSuite(Builder builder) {
+    sizeFactor = builder.sizeFactor;
+    stringArrayMode = builder.stringArrayMode;
+    iterations = builder.iterations;
+  }
+
+  @Override
+  public Iterator<CasSourceTargetConfiguration> iterator() {
     List<CasSourceTargetConfiguration> confs = new ArrayList<>();
 
-    for (int n = 0; n < aCount; n++) {
+    for (int n = 0; n < iterations; n++) {
       MultiFeatureRandomCasGenerator randomizer = MultiFeatureRandomCasGenerator.builder() //
-              .withSize((aCount + 1) * 10) //
+              .withStringArrayMode(stringArrayMode).withSize((n + 1) * sizeFactor) //
               .build();
 
       CasConfiguration cfg = new CasConfiguration(randomizer);
@@ -44,6 +60,51 @@ public class MultiFeatureRandomCasDataSuite {
               .build());
     }
 
-    return confs;
+    return confs.iterator();
+  }
+
+  @Override
+  public int size() {
+    return iterations;
+  }
+
+  /**
+   * Creates builder to build {@link MultiFeatureRandomCasDataSuite}.
+   * 
+   * @return created builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to build {@link MultiFeatureRandomCasDataSuite}.
+   */
+  public static final class Builder {
+    private int iterations = 10;
+    private int sizeFactor = 10;
+    private StringArrayMode stringArrayMode = ALLOW_NULL_AND_EMPTY_STRINGS;
+
+    private Builder() {
+    }
+
+    public Builder withSizeFactory(int aSizeFactory) {
+      sizeFactor = aSizeFactory;
+      return this;
+    }
+
+    public Builder withStringArrayMode(StringArrayMode aStringArrayMode) {
+      stringArrayMode = aStringArrayMode;
+      return this;
+    }
+
+    public Builder withIterations(int aIterations) {
+      iterations = aIterations;
+      return this;
+    }
+
+    public MultiFeatureRandomCasDataSuite build() {
+      return new MultiFeatureRandomCasDataSuite(this);
+    }
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/ProgrammaticallyCreatedCasDataSuite.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/datasuites/ProgrammaticallyCreatedCasDataSuite.java
@@ -21,6 +21,8 @@ package org.apache.uima.cas.serdes.datasuites;
 import static java.util.Arrays.asList;
 
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractCollection;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.uima.cas.ByteArrayFS;
@@ -29,10 +31,13 @@ import org.apache.uima.cas.serdes.transitions.CasSourceTargetConfiguration;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.util.CasCreationUtils;
 
-public class ProgrammaticallyCreatedCasDataSuite {
+public class ProgrammaticallyCreatedCasDataSuite
+        extends AbstractCollection<CasSourceTargetConfiguration> implements CasDataSuite {
 
-  public static List<CasSourceTargetConfiguration> configurations() {
-    return asList( //
+  private final List<CasSourceTargetConfiguration> confs;
+
+  private ProgrammaticallyCreatedCasDataSuite(Builder builder) {
+    confs = asList( //
             CasSourceTargetConfiguration.builder() //
                     .withTitle("casWithText") //
                     .withSourceCasSupplier(ProgrammaticallyCreatedCasDataSuite::casWithText) //
@@ -55,6 +60,16 @@ public class ProgrammaticallyCreatedCasDataSuite {
                             ProgrammaticallyCreatedCasDataSuite::casWithSofaDataArray)
                     .withTargetCasSupplier(CasCreationUtils::createCas) //
                     .build());
+  }
+
+  @Override
+  public Iterator<CasSourceTargetConfiguration> iterator() {
+    return confs.iterator();
+  }
+
+  @Override
+  public int size() {
+    return confs.size();
   }
 
   public static CAS emptyCas() throws Exception {
@@ -97,5 +112,26 @@ public class ProgrammaticallyCreatedCasDataSuite {
     cas.setSofaDataArray(sofaDataArray, "text/plain");
 
     return cas;
+  }
+
+  /**
+   * Creates builder to build {@link ProgrammaticallyCreatedCasDataSuite}.
+   * 
+   * @return created builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to build {@link ProgrammaticallyCreatedCasDataSuite}.
+   */
+  public static final class Builder {
+    private Builder() {
+    }
+
+    public ProgrammaticallyCreatedCasDataSuite build() {
+      return new ProgrammaticallyCreatedCasDataSuite(this);
+    }
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/generators/MultiFeatureRandomCasGenerator.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/generators/MultiFeatureRandomCasGenerator.java
@@ -19,12 +19,14 @@
 package org.apache.uima.cas.serdes.generators;
 
 import static org.apache.uima.UIMAFramework.getResourceSpecifierFactory;
+import static org.apache.uima.cas.serdes.generators.MultiFeatureRandomCasGenerator.StringArrayMode.ALLOW_NULL_AND_EMPTY_STRINGS;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.uima.cas.ArrayFS;
 import org.apache.uima.cas.ByteArrayFS;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.DoubleArrayFS;
@@ -90,7 +92,9 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
   private final boolean includeUid;
   private final Random rnd;
   private final int size;
+  private final StringArrayMode stringArrayMode;
 
+  // akof = all kinds of features
   private Type akof;
   private Feature akofUid;
   private Feature akofInt;
@@ -116,10 +120,11 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
   private AtomicInteger aint;
 
   private MultiFeatureRandomCasGenerator(Builder builder) {
-    this.isKeep = builder.isKeep;
-    this.includeUid = builder.includeUid;
-    this.rnd = builder.randomGenerator;
-    this.size = builder.size;
+    isKeep = builder.isKeep;
+    includeUid = builder.includeUid;
+    rnd = builder.randomGenerator;
+    size = builder.size;
+    stringArrayMode = builder.stringArrayMode;
     aint = includeUid ? new AtomicInteger(0) : null;
   }
 
@@ -203,6 +208,7 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
     // Randomly link feature structures to each other
     for (FeatureStructure fs : lfss) {
       fs.setFeatureValue(akofFs, lfss.get(rnd.nextInt(lfss.size())));
+      ((ArrayFS) fs.getFeatureValue(akofAfs)).set(0, lfss.get(rnd.nextInt(lfss.size())));
     }
   }
 
@@ -243,15 +249,25 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
   }
 
   private String randomString(Random r) {
-    int i = r.nextInt(7);
-    return STRING_VALUES[i];
+    String v = STRING_VALUES[r.nextInt(STRING_VALUES.length)];
+
+    switch (stringArrayMode) {
+      case ALLOW_NULL_AND_EMPTY_STRINGS:
+        return v;
+      case EMPTY_STRINGS_AS_NULL:
+        return v != null && v.isEmpty() ? null : v;
+      case NULL_STRINGS_AS_EMPTY:
+        return v == null ? "" : v;
+      default:
+        throw new IllegalArgumentException("Unsupported string array mode: " + stringArrayMode);
+    }
   }
 
   private StringArrayFS randomStringA(Random r) {
     int length = r.nextInt(2) + 1;
     StringArrayFS fs = maybeKeep(cas.createStringArrayFS(length));
     for (int i = 0; i < length; i++) {
-      fs.set(i, STRING_VALUES[r.nextInt(STRING_VALUES.length)]);
+      fs.set(i, randomString(r));
     }
     return fs;
   }
@@ -334,31 +350,37 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
    * Builder to build {@link MultiFeatureRandomCasGenerator}.
    */
   public static final class Builder {
-    private boolean isKeep;
+    private boolean isKeep = true;
     private boolean includeUid;
     private Random randomGenerator;
     private int size;
+    private StringArrayMode stringArrayMode = ALLOW_NULL_AND_EMPTY_STRINGS;
 
     private Builder() {
     }
 
-    public Builder withReferenceKeeping(boolean isKeep) {
-      this.isKeep = isKeep;
+    public Builder withReferenceKeeping(boolean aIsKeep) {
+      isKeep = aIsKeep;
       return this;
     }
 
-    public Builder withUid(boolean includeUid) {
-      this.includeUid = includeUid;
+    public Builder withUid(boolean aIncludeUid) {
+      includeUid = aIncludeUid;
       return this;
     }
 
-    public Builder withRandomGenerator(Random rnd) {
-      this.randomGenerator = rnd;
+    public Builder withRandomGenerator(Random aRandom) {
+      randomGenerator = aRandom;
       return this;
     }
 
-    public Builder withSize(int size) {
-      this.size = size;
+    public Builder withSize(int aSize) {
+      size = aSize;
+      return this;
+    }
+
+    public Builder withStringArrayMode(StringArrayMode aStringArrayMode) {
+      stringArrayMode = aStringArrayMode;
       return this;
     }
 
@@ -369,5 +391,23 @@ public class MultiFeatureRandomCasGenerator implements CasGenerator {
 
       return new MultiFeatureRandomCasGenerator(this);
     }
+  }
+
+  public enum StringArrayMode {
+    /**
+     * Instead of generating an empty string, generate a {@code null} value (mainly for XCAS).
+     */
+    EMPTY_STRINGS_AS_NULL,
+
+    /**
+     * Instead of generating a {@code null} value, generate an empty string (mainly for XMI).
+     */
+    NULL_STRINGS_AS_EMPTY,
+
+    /**
+     * Generate both {@code null} values and empty strings (this is what (de)serializers should
+     * normally support and be tested with).
+     */
+    ALLOW_NULL_AND_EMPTY_STRINGS;
   }
 }


### PR DESCRIPTION
- Allow configuration of empty/null elements in StringArrayFS when the MultiFeatureRandomCasDataSuite is used
- Fixes XMI and XCAS tests against the MultiFeatureRandomCasDataSuite
- Improve stability of order of feature structures in CasToComparableText by introducing a non-recursive "featureHash"