### PR TITLE
Removed unnecessary code from Class_TCCL.java

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/internal/util/Class_TCCL.java
+++ b/uimaj-core/src/main/java/org/apache/uima/internal/util/Class_TCCL.java
@@ -73,11 +73,6 @@ public class Class_TCCL {
 
     if (cl == null) {
       cl = get_parent_cl();
-      Thread.currentThread().getContextClassLoader();
-    }
-
-    if (cl == null) {
-      cl = Class_TCCL.class.getClassLoader(); // this class's classloader
     }
 
     return cl;


### PR DESCRIPTION
The code that was removed was already executed via get_parent_cl and was therefor unecessary.