### PR TITLE
[UIMA-6401] CPE ThreadGroupDestroyer keeps unnecessary reference on CPMEngine

### DIFF
--- a/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
+++ b/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
@@ -1,21 +1,21 @@
-#	 ***************************************************************
-#	 * Licensed to the Apache Software Foundation (ASF) under one
-#	 * or more contributor license agreements.  See the NOTICE file
-#	 * distributed with this work for additional information
-#	 * regarding copyright ownership.  The ASF licenses this file
-#	 * to you under the Apache License, Version 2.0 (the
-#	 * "License"); you may not use this file except in compliance
-#	 * with the License.  You may obtain a copy of the License at
+#  ***************************************************************
+#  * Licensed to the Apache Software Foundation (ASF) under one
+#  * or more contributor license agreements.  See the NOTICE file
+#  * distributed with this work for additional information
+#  * regarding copyright ownership.  The ASF licenses this file
+#  * to you under the Apache License, Version 2.0 (the
+#  * "License"); you may not use this file except in compliance
+#  * with the License.  You may obtain a copy of the License at
 #    *
-#	 *   http://www.apache.org/licenses/LICENSE-2.0
-#	 * 
-#	 * Unless required by applicable law or agreed to in writing,
-#	 * software distributed under the License is distributed on an
-#	 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-#	 * KIND, either express or implied.  See the License for the
-#	 * specific language governing permissions and limitations
-#	 * under the License.
-#	 ***************************************************************
+#  *   http://www.apache.org/licenses/LICENSE-2.0
+#  * 
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied.  See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  ***************************************************************
 
 #---------------------------------------------------------
 #Messages written to log file by cpm implementation 
@@ -61,7 +61,7 @@ UIMA_CPM_EXP_service_not_defined__WARNING = The service {1} is not defined.  \
 
 UIMA_CPM_EXP_queue_size_not_defined__WARNING = A queue size is not defined.  \
   Check the CPE descriptor for the CAS processors attribute name {1}. \
-    (Thread Name: {0}) 	
+    (Thread Name: {0})  
 
 
 UIMA_CPM_EXP_not_directory__WARNING = {1} is not a directory.  \
@@ -116,9 +116,9 @@ UIMA_CPM_EXP_missing_attribute_from_xml_element__WARNING = The CPE descriptor is
   (Thread Name: {0})
 
 UIMA_CPM_EXP_bad_action_string__WARNING = The CPE descriptor is invalid. The value action string \
-	in element {2} of the CAS processor {1} is invalid. \
-	[continue|terminate|disable] is expected but {3} was obtained. \
-	  (Thread Name: {0}) 
+  in element {2} of the CAS processor {1} is invalid. \
+  [continue|terminate|disable] is expected but {3} was obtained. \
+    (Thread Name: {0}) 
 
 UIMA_CPM_Exception_invalid_deployment__WARNING = The CPE descriptor is invalid. The deployment type for the CAS processor {1} is invalid. [local|remote|integrated] is expected but {2} was obtained. \
   (Thread Name: {0}) 
@@ -199,143 +199,143 @@ UIMA_CPM_unable_to_deploy_service__SEVERE = The CAS processor {1} cannot be depl
   (Thread Name: {0}) 
 
 UIMA_CPM_deploy_with_mode__FINEST = Deploying CasProcessor: \
-	(Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_cp_with_exclusive_access__FINEST = Cas Processor configured for exclusive access. \
-	(Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_no_service_in_vns__FINEST = Unable to find vinci service in the VNS. \
-	(Thread Name: {0}) Vinci Service Name: {1} Using: {2} Deployment. Using VNS_HOST: {3} and VNS_PORT:{4}
+  (Thread Name: {0}) Vinci Service Name: {1} Using: {2} Deployment. Using VNS_HOST: {3} and VNS_PORT:{4}
 
 UIMA_CPM_retrieve_cp_from_failed_cplist__FINEST = Retrieving Cas Processor instance from the list of failed cas processors. \
-	(Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_connecting_to_service__FINEST = Attempting Connection to Remote Service. \
-	(Thread Name: {0}) Service Name: {1}
+  (Thread Name: {0}) Service Name: {1}
 
 UIMA_CPM_got_port_from_queue__INFO = The next port {1} was retrieved from the service port queue. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_invalid_retry_count__INFO = The value of DCONN_RETRY_COUNT is invalid. Check the command line. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_service_port_not_allocated__INFO = The service port is not available yet. There are {1} retries left to acquire the port. \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_binding_to_service__FINEST = Binding Proxy to Service. \
-	(Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_no_cp_instance_in_failed_list__FINEST = Unable to acquire Cas Processor instance from the Failed Cas Processor Pool. \
-	(Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_already_allocated__FINEST = Already Allocated and Connected to Service. \
-	(Thread Name: {0}) Current Instance Index: {1}
+  (Thread Name: {0}) Current Instance Index: {1}
 
 UIMA_CPM_assign_cp_to_service__FINEST = Assigning CasProcessor to Service. \
-	(Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_connection_established__FINEST = Connection Established with Remote Service. \
-	(Thread Name: {0}) Service Name: {1}
+  (Thread Name: {0}) Service Name: {1}
 
 UIMA_CPM_get_cp_from_pool_error__SEVERE= There are no CAS processors in the CAS processor pool. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} Currently available CAS processor instances in pool: {3}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} Currently available CAS processor instances in pool: {3}
 
 UIMA_CPM_get_cp_from_pool__FINEST = Checking Out Instance of CasProcessor From Pool. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} Currently Available in Pool: {3} CP Instances
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} Currently Available in Pool: {3} CP Instances
 
 UIMA_CPM_checkin_cp_to_pool__FINEST = Checking-In Instance of CasProcessor to Pool. \
-	(Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
+  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
 
 
 UIMA_CPM_checked_in_cp_to_pool__FINEST = Checked-In Instance of CasProcessor to Pool. \
-	(Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
+  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
 
 UIMA_CPM_max_connect_retries_exceeded__FINEST = Service Connection Exception. Max number of retries reached. \
-	(Thread Name: {0}) Service Name: {1} Max Retry Count: {2}
+  (Thread Name: {0}) Service Name: {1} Max Retry Count: {2}
 
 UIMA_CPM_activating_service__FINEST = Activating Service Proxy. \
-	(Thread Name: {0}) Cas Processor Name: {1} Proxy {2} of {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Proxy {2} of {3}
 
 UIMA_CPM_thread_count__FINEST = Concurrent Processing Pipeline Count. \
-	(Thread Name: {0}) Cas Processor Name: {1} Pipeling Count: {2}
+  (Thread Name: {0}) Cas Processor Name: {1} Pipeling Count: {2}
 
 UIMA_CPM_test_vns_port__INFO =  The CPM is about to test its VNS port {1} for availability. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_activating_vns_port__INFO =  The CPM VNS activity started on port {1}. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_vns_process_serveon__FINEST =  VNS received a serveon request. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_assign_service_port__FINEST = Assigning Service Port. \
-	(Thread Name: {0}) Service PORT: {1} 
+  (Thread Name: {0}) Service PORT: {1} 
 
 UIMA_CPM_vns_shutdown__INFO = The CPM VNS received a request to stop. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_vns_stopped_serving__INFO = The CPM VNS activity stopped. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_launching_local_vns__INFO = The CPM VNS thread started. \
-	(Thread Name: {0}) VNS Port: {1} 
+  (Thread Name: {0}) VNS Port: {1} 
 
 UIMA_CPM_launching_local_vns_failed__SEVERE = VNS cannot start. \
-	(Thread Name: {0}) Failure Reason: {1} 
+  (Thread Name: {0}) Failure Reason: {1} 
 
 UIMA_CPM_service_active_on_port__FINEST = Service Active. \
-	(Thread Name: {0}) Service Name: {1} Service Host: {2} Service PORT: {3}.
+  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service PORT: {3}.
 
 UIMA_CPM_service_not_active_on_port__WARNING = The service {1} is not active. \
-	(Thread Name: {0}) Service Host: {2} Service Port: {3}.
+  (Thread Name: {0}) Service Host: {2} Service Port: {3}.
 
 UIMA_CPM_vns_redirect__FINEST = Redirecting Vinci <resolve> request to public VNS. \
-	(Thread Name: {0}) Public VNS HOST: {1} Public VNS HOST: {2}
+  (Thread Name: {0}) Public VNS HOST: {1} Public VNS HOST: {2}
 
 UIMA_CPM_unknown_vns_command__WARNING = Unknown VINCI command. \
-	(Thread Name: {0})  
+  (Thread Name: {0})  
 
 UIMA_CPM_assign_service_port_complete__FINEST = Completed Assigning Service Port. \
-	(Thread Name: {0}) Service PORT: {1} 
+  (Thread Name: {0}) Service PORT: {1} 
 
 UIMA_CPM_deactivating_vns_port__INFO =  VNS stopped. \
-	(Thread Name: {0})  
+  (Thread Name: {0})  
 
 UIMA_CPM_vns_port_not_available__SEVERE = No port can be acquired for the VNS service. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_test_local_port__INFO = The service port {1} is available on localhost. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_activating_service_on_port__FINEST = Activating Service Proxy. \
-	(Thread Name: {0}) Cas Processor Name: {1} Service Port Proxy {2} 
+  (Thread Name: {0}) Cas Processor Name: {1} Service Port Proxy {2} 
 
 UIMA_CPM_activating_service_on_port2__FINEST = Activating Service Proxy. \
-	(Thread Name: {0}) Cas Processor Name: {1} Index: {2} of {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Index: {2} of {3}
 
 UIMA_CPM_service_exception__WARNING = Trying to reconnect the service proxy {2} of {3}. \
-	(Thread Name: {0}) CAS processor name: {1}
+  (Thread Name: {0}) CAS processor name: {1}
 
 UIMA_CPM_cp_checkpoint__FINEST = Check point for this cas processor. \
-	(Thread Name: {0}) Batch Size: {1} 
-	
+  (Thread Name: {0}) Batch Size: {1} 
+  
 UIMA_CPM_invalid_service_descriptor__SEVERE = {1} in {2} of the descriptor for this CAS processor is missing. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_killing_process__FINEST = Killing Process. \
-	(Thread Name: {0}) Process PID: {1} 
-	
+  (Thread Name: {0}) Process PID: {1} 
+  
 UIMA_CPM_show_sys_env__FINEST = System Environment Variable. \
-	(Thread Name: {0}) Env Key: {1} Env Value: {2}
-	
+  (Thread Name: {0}) Env Key: {1} Env Value: {2}
+  
 UIMA_CPM_set_service_timeout__FINEST = Setting Service Timeout. \
-	(Thread Name: {0}) Service Timeout: {1} 
+  (Thread Name: {0}) Service Timeout: {1} 
 
 UIMA_CPM_connect_to_service__FINEST = Connecting TAP to service. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
-	
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  
 UIMA_CPM_connected_to_service__FINEST = Connected TAP to service. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_testing_connection__FINEST = Testing Established Connection. \
 (Thread Name: {0}) Sleeping for 100ms and Getting Metadata
@@ -347,258 +347,258 @@ UIMA_CPM_connection_closed__FINEST = Connection appears to be closed. \
 (Thread Name: {0}) Service PID: {1}
 
 UIMA_CPM_connection_not_established__WARNING = No connection has been established Yet. Attempting to reconnect. Sleeping for 100ms first. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_connection_failed__WARNING = The system is unable to connect to the service host {1} through the service port {2}. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_service_down__INFO = The service {1} is not running. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_use_default_metadata__FINEST = Defaulting to metadata in CPE Descriptor. \
-	(Thread Name: {0}) Service Name: {1}
+  (Thread Name: {0}) Service Name: {1}
 
 UIMA_CPM_no_metadata__FINEST = Container Metadata is Null. \
-	(Thread Name: {0}) Service Name: {1}
+  (Thread Name: {0}) Service Name: {1}
 
 UIMA_CPM_no_cp_configuration_in_metadata__FINEST = Container Metadata does not include casProcessor Configuration. \
-	(Thread Name: {0}) Service Name: {1}
+  (Thread Name: {0}) Service Name: {1}
 
 UIMA_CPM_service_down_onhost__INFO = The service hosted on {1} and port {2} is not running. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_memory_before_call__FINEST = Show Total Memory Available Before vinci Call (kb). \
-	(Thread Name: {0}) Available Memory : {1} Total Memory: {2}
+  (Thread Name: {0}) Available Memory : {1} Total Memory: {2}
 
 UIMA_CPM_show_memory__FINEST = Show Memory. \
-	(Thread Name: {0})  Total Memory: {1} Available Memory: {2}
+  (Thread Name: {0})  Total Memory: {1} Available Memory: {2}
 
 UIMA_CPM_show_total_memory__FINEST = Show Total Memory. \
-	(Thread Name: {0})  Total Memory: {1} 
+  (Thread Name: {0})  Total Memory: {1} 
 
 UIMA_CPM_checkout_cp_from_container__FINEST = Checking out Cas Processor from Container. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_checkedout_cp_from_container__FINEST = Checked out Cas Processor from Container. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
 
 UIMA_CPM_is_container_paused__FINEST = Container Status. \
-	(Thread Name: {0}) Container Name: {1} Is Paused: {2}
+  (Thread Name: {0}) Container Name: {1} Is Paused: {2}
 
 UIMA_CPM_checkout_null_cp_from_container__SEVERE = The CAS processor in container {1} is NULL. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_container_not_ready__FINEST = Container Disabled. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_analysis_successfull__FINEST = Analysis has been successfull. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_end_of_batch__FINEST = Doing End-Of-Batch. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_release_cp__FINEST = Releasing CasProcessor to the Pool.. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
 
 UIMA_CPM_ok_release_cp__FINEST = Released CasProcessor to the Pool.. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
 
 UIMA_CPM_ok_released_cp__FINEST = Released CasProcessor to the Pool.. \
-	(Thread Name: {0}) Container Name: {1} 
-	
+  (Thread Name: {0}) Container Name: {1} 
+  
 UIMA_CPM_container_paused__FINEST = Container has been paused. Released Cases. \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 UIMA_CPM_pipeline_completed__FINEST = Processing Pipeline Pass Complete. Analysis Has Been Done. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_pipeline_exception__SEVERE = The container {1} returned the following error message: {2} \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_notify_listeners__FINEST = Notifying Listeners. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_done_notify_listeners__FINEST =  Done Notifying Listeners. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_add_cas_to_queue__FINEST = Adding Results of Analysis to Queue. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_done_with_cas__FINEST = Cas in Queue. Nullifying References to CAS. \
-	(Thread Name: {0})  Current Memory: {1}
+  (Thread Name: {0})  Current Memory: {1}
 
 UIMA_CPM_nullify_cas__FINEST = Nullifying References to CAS. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_local_cache__FINEST = Local Cas Cache. \
-	(Thread Name: {0})  Is Cas Cache Null: {1}
+  (Thread Name: {0})  Is Cas Cache Null: {1}
 
 UIMA_CPM_end_of_batch_completed__FINEST = Done With End-Of-Batch. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_end_of_batch_exception__SEVERE = The method isEndOfBatch() in container {1} returned the following error message: {2} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_handle_exception__SEVERE = The container {1} is processing error message {3} generated by CAS processor {2}. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_drop_cas__WARNING = The CAS is being dropped due to the CPM error handling configuration. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_container_paused_do_retry__FINEST = Container has been paused. Retrying the same document once the container is resumed. \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 UIMA_CPM_pausing_container__FINEST = Pausing Container. \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 UIMA_CPM_exception_on_pipeline_kill__WARNING = A request to stop a processing pipeline cannot be processed. The current container is {1}. \
-	(Thread Name: {0}) Reason: {2}
+  (Thread Name: {0}) Reason: {2}
 
 UIMA_CPM_exception_on_cpm_kill__WARNING = The CPM cannot be stopped by force. The current container is {1}. \
-	(Thread Name: {0}) Reason: {2}
-	
+  (Thread Name: {0}) Reason: {2}
+  
 UIMA_CPM_initialize_cas__FINEST = Initializing CAS. \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 UIMA_CPM_casobjectlist_is_null__SEVERE = The method aCasObjectList[casIndex] returns null for container {1} in the CAS index {2}. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_casObjects_class__FINEST = Cas Instance Class. \
-	(Thread Name: {0}) casObjects Class Name: {1} 
+  (Thread Name: {0}) casObjects Class Name: {1} 
 
 
 UIMA_CPM_call_process__FINEST = Calling Cas Processor process(). \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_call_process_completed__FINEST = Done calling Cas Processor process(). \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_casobject_processor__FINEST = CasObject Cas Processor. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
 
 UIMA_CPM_get_cas_from_pool__FINEST = Retrieving Cas from cas pool. \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 UIMA_CPM_call_processNext__FINEST = Calling processNext() . \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_call_processNext_done__FINEST = Done calling processNext() . \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cas_data_processor__FINEST = CasProcessor is instanceof CasDataProcessor. \
-	(Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
+  (Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
 
 UIMA_CPM_dump_events__FINEST = Dumping Events. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_unexpected_artifact_type__SEVERE = The artifact type is invalid. The artifact class name is {1}. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_expected_casdata__FINEST = Expected CasData. \
-	(Thread Name: {0}) Got: {1} Instead
+  (Thread Name: {0}) Got: {1} Instead
 
 UIMA_CPM_chunk_state_false_timeout__FINEST = Changing chunkState to false due to timeout. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_queue_empty__FINEST = Queue is empty. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_expected_chunk_sequenece__FINEST = Chunk Sequence. \
-	(Thread Name: {0}) Queue Name: {1} Expected Sequence: {2}
+  (Thread Name: {0}) Queue Name: {1} Expected Sequence: {2}
 
 UIMA_CPM_got_eof_token__FINEST = Got EOF Token. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_chunk_meta_is_null__FINEST = ChunkMetadata is NULL. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_sequence_timed_out__FINEST = Sequence Has Timed Out. \
-	(Thread Name: {0}) Queue Name: {1}  Returning CAS with sequence# {2}
+  (Thread Name: {0}) Queue Name: {1}  Returning CAS with sequence# {2}
 
 UIMA_CPM_iscas__FINEST = Object from Queue is Cas. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_in_chunk_state__FINEST = In Chunk State. \
-	(Thread Name: {0}) Queue Name: {1} Expected Doc Id: {2} Got Doc Id: {3} Expected Sequence Id: {4} Got Sequence Id: {5}
-	
+  (Thread Name: {0}) Queue Name: {1} Expected Doc Id: {2} Got Doc Id: {3} Expected Sequence Id: {4} Got Sequence Id: {5}
+  
 UIMA_CPM_change_chunk_state__FINEST = Changing chunkState to false due to the fact the we just processed the last one in the sequence. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_not_in_chunk_state__FINEST = Not In Chunk State. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_begin_chunk_state__FINEST = Begining Chunk State. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_null_cas__FINEST = Not a CAS but NULL object. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_not_cas__FINEST = Unexpected Object Type. \
-	(Thread Name: {0}) Queue Name: {1} Expected CAS. Got {2} instead
+  (Thread Name: {0}) Queue Name: {1} Expected CAS. Got {2} instead
 
 UIMA_CPM_done_scanning_q__FINEST = Done With Scanning The Queue. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_expecte_seq_not_found__FINEST = Expected Sequence Not Found. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_show_queue_capacity__FINEST = Queue Capacity. \
-	(Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Current Queue Size: {3}
+  (Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Current Queue Size: {3}
 
 UIMA_CPM_wait_for_chunk__FINEST = No Expected Chunk Sequnce - Waiting Some More. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_timedout_waiting_for_chunk__FINEST = Timed Out While Waiting For Chunk Sequnce.. \
-	(Thread Name: {0}) Queue Name: {1} Doc ID: {2}  Skipping the document.
-	
+  (Thread Name: {0}) Queue Name: {1} Doc ID: {2}  Skipping the document.
+  
 UIMA_CPM_chunk_didnt_arrive__FINEST = Expected Chunk didnt arrive within a given window. \
-	(Thread Name: {0}) Queue Name: {1} Window (timeout): {2}  Changing chunkState to false.
-	
+  (Thread Name: {0}) Queue Name: {1} Window (timeout): {2}  Changing chunkState to false.
+  
 UIMA_CPM_return_chunk__FINEST = Returning from Queue. \
-	(Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Queue Current Size: {3}
-	
+  (Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Queue Current Size: {3}
+  
 UIMA_CPM_cas_not_valid__FINEST = CAS is NULL || CAS not CasData. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_timer_expired__FINEST = Timer Has Expired. \
-	(Thread Name: {0}) Doc ID: {1} Cache Size: {2}
+  (Thread Name: {0}) Doc ID: {1} Cache Size: {2}
 
 UIMA_CPM_expression__FINEST = Expression . \
-	(Thread Name: {0}) expr: {1}
+  (Thread Name: {0}) expr: {1}
 
 UIMA_CPM_java_timer__CONFIG = TimerFactory-instantiating JavaTimer. Higher precision Timer not specified. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_show_timer_class__CONFIG = Instantiating Timer Object. \
-	(Thread Name: {0}) Timer Class Name: {1}
+  (Thread Name: {0}) Timer Class Name: {1}
 
 UIMA_CPM_show_cas_fs_type__FINEST = CAS FEATURE STRUCTURE Type. \
-	(Thread Name: {0}) FS Type: {1}
+  (Thread Name: {0}) FS Type: {1}
 
 UIMA_CPM_show_cas_fs_value__FINEST = CAS FEATURE STRUCTURE Value. \
-	(Thread Name: {0}) FS Name: {1} FS Value: {2}
+  (Thread Name: {0}) FS Name: {1} FS Value: {2}
 
 UIMA_CPM_search_cas_by_value__FINEST= Search Cas by feature Name. \
-	(Thread Name: {0}) FS Name: {1} FS Type: {2}
+  (Thread Name: {0}) FS Name: {1} FS Type: {2}
 
 UIMA_CPM_show_type_value__FINEST = Feature Structure Type and Value. \
-	(Thread Name: {0}) FS Type: {1} FS Value: {2}
+  (Thread Name: {0}) FS Type: {1} FS Value: {2}
 
 UIMA_CPM_cpm_init_complete__CONFIG = Collection Processsing managers initialization completed. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_method_ping__FINEST = Method Call. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_failed_component__FINEST = Component Failed. \
-	(Thread Name: {0}) Component: {1}
+  (Thread Name: {0}) Component: {1}
 
 UIMA_CPM_component_exception__FINEST = Failed Component Exception. \
-	(Thread Name: {0}) Exception: {1}
+  (Thread Name: {0}) Exception: {1}
 
 
 UIMA_CPM_show_total_time_in_cpm__FINEST = Total Time in CPM. \
-	(Thread Name: {0}) Time: {1}
+  (Thread Name: {0}) Time: {1}
 
 
 
@@ -609,513 +609,513 @@ UIMA_CPM_show_total_time_in_cpm__FINEST = Total Time in CPM. \
 
 
 UIMA_CPM_artifact_null__SEVERE = The artifact is empty. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_exit_pp__FINEST = Exiting from CPM Processing Unit. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_pp_terminated__FINEST = Processing Pipeline Completed Processing CAS. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 
 UIMA_CPM_drop_key__FINEST = Dropping Vinci Keys. \
-	(Thread Name: {0}) Key: {1}
+  (Thread Name: {0}) Key: {1}
 
 UIMA_CPM_analyze_bundle__FINEST = Analyzing CAS Bundle. \
-	(Thread Name: {0}) Bundle Size: {1}
+  (Thread Name: {0}) Bundle Size: {1}
 
 UIMA_CPM_dump_casdata__FINEST = CasData Key Dump. \
-	(Thread Name: {0}) Key: {1}
+  (Thread Name: {0}) Key: {1}
 
 UIMA_CPM_no_casdata__FINEST = CasData is Empty. \
-	(Thread Name: {0}) Skipping to the next...
-	
+  (Thread Name: {0}) Skipping to the next...
+  
 UIMA_CPM_send_casdata_to_service__FINEST = Sending request to service. \
-	(Thread Name: {0}) Service Name: {1}
-	
+  (Thread Name: {0}) Service Name: {1}
+  
 UIMA_CPM_done_analyzing_bundle__FINEST = Done Analyzing Cas Data Bundle. Returning Results. \
-	(Thread Name: {0}) Bundle Size: {1}
+  (Thread Name: {0}) Bundle Size: {1}
 
-	
+  
 UIMA_CPM_show_memory_after_call__FINEST = Show Total Memory After vinci Call (kb). \
-	(Thread Name: {0}) Available Memory : {1} Total Memory: {2}
+  (Thread Name: {0}) Available Memory : {1} Total Memory: {2}
 
 UIMA_CPM_received_response__FINEST = Returning Response. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_failed_service_request__WARNING = A service error occurred when processing a document. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_exception__FINER = Got Exception. \
-	(Thread Name: {0}) Message: {1}
-	
-# https://issues.apache.org/jira/browse/UIMA-2440	
+  (Thread Name: {0}) Message: {1}
+  
+# https://issues.apache.org/jira/browse/UIMA-2440 
 UIMA_CPM_exception__WARNING = Got Exception. \
-  (Thread Name: {0}) Message: {1}	
+  (Thread Name: {0}) Message: {1} 
 
 UIMA_CPM_cr_exception__SEVERE = The CPM collection reader returned the following error message: {1} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cc_exception__SEVERE = The CAS consumer returned the following error message: {1} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_service_connection_exception__SEVERE = The service returned the following error: {1} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_service_exception__SEVERE = THE CPM service returned the following error message: {1} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_waiting_for_service_shutdown__FINEST = Waiting for service to cleanup on shutdown. \
-	(Thread Name: {0}) Attempt: {1} of {2}
+  (Thread Name: {0}) Attempt: {1} of {2}
 
 UIMA_CPM_service_shutdown_completed__FINEST = Service Shutdown Completed. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_stopping_cp__FINEST = STOPPING CasProcessor. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_deploy_logger__FINEST = Deploying Logger. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_logpath_not_defined__FINEST = Container Log Path Not Defined. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_increment_cp_errors__FINEST = Incrementing Cas Processor Errors. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_show_cp_error_count__FINEST = Show Current Error Count. \
-	(Thread Name: {0}) Container Name: {1} Error Count: {2} Message: {3}
+  (Thread Name: {0}) Container Name: {1} Error Count: {2} Message: {3}
 
 UIMA_CPM_abort_cpm__SEVERE = The CPM is terminating. The current component is {1}. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_disable_cp__SEVERE = CAS processor {1} is disabled. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_cp_batch_size__FINEST = Cas Processor Batch Size. \
-	(Thread Name: {0}) Component Name: {1}  Batch Size: {2}
+  (Thread Name: {0}) Component Name: {1}  Batch Size: {2}
 
 UIMA_CPM_show_cp_doc_count__FINEST = Cas Processor Processed Docs. \
-	(Thread Name: {0}) Component Name: {1}  So Far Processed: {2} Docs
+  (Thread Name: {0}) Component Name: {1}  So Far Processed: {2} Docs
 
 UIMA_CPM_cp_is_null__SEVERE = The CPM is in an unexpected state. The CAS processor is NULL. The component name is {1}. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_check_filter__FINEST = Checking CP Filter. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_filtering_disabled__FINEST = Filtering disabled (not defined). \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_filter_empty__FINEST = FilterList is empty. \
-	(Thread Name: {0}) Component Name: {1} 
-	
+  (Thread Name: {0}) Component Name: {1} 
+  
 UIMA_CPM_filter_enabled__FINEST = Filtering enabled. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_filter_enabled_no_right_operand__FINEST = No right Operand. Evaluating Filter Expression. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_pause_container__FINEST = Pausing Cas Processor Container. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_pause_cpe__FINEST = Pausing CPE. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_resume_cpe__FINEST = Resuming CPE after Pause. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_notify_engine__FINEST = Notifying Engine. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_pipeline_terminated__FINEST = Processing Pipeline Terminated. \
-	(Thread Name: {0}) Pipeline Thread Name: {1}
-	
+  (Thread Name: {0}) Pipeline Thread Name: {1}
+  
 UIMA_CPM_exception_while_consuming_cases__SEVERE = The following error message was returned While consuming CASes from the work queue during a forced shutdown: {1} \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_exception_in_single_threaded_cpm__SEVERE = The following error message was returned while running the single-threaded CPM: {1} \
-	(Thread Name: {0})  
+  (Thread Name: {0})  
 
 UIMA_CPM_starting_cpe__FINEST =Starting Collection Processing Engine. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_redefine_pool_size__CONFIG = CAS PoolSize exceeds hard limit(100). \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_show_cas_pool_size__CONFIG = Cas Pool Size. \
-	(Thread Name: {0}) Current Size: {1}
-	
+  (Thread Name: {0}) Current Size: {1}
+  
 UIMA_CPM_got_cas_from_pool__FINEST = Got Cas from Cas Pool. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 
 UIMA_CPM_create_producer__CONFIG = Instantiating Producer. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_create_pus__CONFIG = Starting PUs. \
-	(Thread Name: {0}) Work Queue Size: {1}
+  (Thread Name: {0}) Work Queue Size: {1}
 
 UIMA_CPM_resuming_container__FINEST = Resuming Cas Processor Container. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_checking_out_cp_from_pool__FINEST = Checking Out CasProcessor from Pool. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_checking_in_cp_to_pool__FINEST = Returning CasProcessor to Pool. \
-	(Thread Name: {0}) Total Size: {1} Free In Pool: {2}
+  (Thread Name: {0}) Total Size: {1} Free In Pool: {2}
 
 UIMA_CPM_checking_in_invalid_cp_to_pool__FINEST = An attempt is being made to return a CAS processor to a pool from which it was not checked out. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cp_not_in_pool__FINEST = Cas Processor Instance Not in mAllInstances. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cp_already_checked_in__FINEST = Cas Processor Already Checked In to mFreeInstances. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_add_cp_to_pool__FINEST = Adding Cas Processor to Processor Instance Pool. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_reset_queue_size__FINEST = Resetting queue size to max process size. \
-	(Thread Name: {0}) New Queue Size: {1}
+  (Thread Name: {0}) New Queue Size: {1}
 
 UIMA_CPM_enqueue_cas_bundle__FINEST = Enqueing Cas Bundle. \
-	(Thread Name: {0}) Cas Bundle Size: {1}
+  (Thread Name: {0}) Cas Bundle Size: {1}
 
 UIMA_CPM_show_cr_progress__FINEST = Collection Reader Progress. \
-	(Thread Name: {0}) CR Processed: {1} Documents So Far
+  (Thread Name: {0}) CR Processed: {1} Documents So Far
 
 UIMA_CPM_cr_fetch_new_cas__FINEST = Collection Reader Fetch New CAS instance from Pool. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cr_check_cas_for_null__FINEST = Collection Reader Retrieved New CAS Instance From Pool. \
-	(Thread Name: {0}) Is Cas NULL: {1}
-	
+  (Thread Name: {0}) Is Cas NULL: {1}
+  
 UIMA_CPM_in_shutdown_state__FINEST = CPM is in shutdown state.Returning null from getNext(). \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_got_new_cas__FINEST = Collection Reader Fetched New CAS instance from Pool. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_call_cas_reset__FINEST = Calling Reset on CAS. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_call_cr_next__FINEST = Calling CR.getNext(). \
-	(Thread Name: {0}) CAS Type: {1}
+  (Thread Name: {0}) CAS Type: {1}
 
 UIMA_CPM_call_cr_next_finished__FINEST = Done Calling CR.getNext(). \
-	(Thread Name: {0}) CAS Type: {1}
+  (Thread Name: {0}) CAS Type: {1}
 
 UIMA_CPM_return_cases_from_cr__FINEST = Returning CAS from CollectionReader. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 
 UIMA_CPM_show_cp_pool_size__FINEST = Cas Processor Pool. \
-	(Thread Name: {0}) Total Size: {1} Free In Pool: {2}
-	
+  (Thread Name: {0}) Total Size: {1} Free In Pool: {2}
+  
 UIMA_CPM_cp_pool_empty__WARNING = The CAS processor pool is empty. \
-	(Thread Name: {0}) Total size: {1} Free in pool: {2}
+  (Thread Name: {0}) Total size: {1} Free in pool: {2}
 
 UIMA_CPM_cpm_not_running__WARNING = The CPM is not running. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_start_pp__FINEST = Starting Processing Pipeline. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
-	
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  
 UIMA_CPM_dequeue_artifact__FINEST = Dequeueing next artifact from queue. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_maxwait_for_artifact__FINEST = Max Wait for artifact. \
-	(Thread Name: {0}) Wait Time: {1}
+  (Thread Name: {0}) Wait Time: {1}
 
 
 UIMA_CPM_cr_done_producing__FINEST = Artifact Producer Done Producing. \
-	(Thread Name: {0}). Adding EOF Marker
+  (Thread Name: {0}). Adding EOF Marker
 
 UIMA_CPM_eof_marker_enqueued__FINEST = Placed EOF Marker in Work Queue. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_placed_eof_in_queue__FINEST = Adding EOF Marker in Queue. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_done_placed_eof_in_queue__FINEST = Done Adding EOF Marker in Queue. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_done_notifying_queue__FINEST = Done Notifying Queue. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_exception_adding_eof__SEVERE = The following error message was returned while adding the end-of-file token to the output queue: {1} \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_cc_completed__FINEST = CasConsumer Thread is Done. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_pus_completed__FINEST = All Processing Pipelined completed. Unloading Output Queue. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_cleaning_up_pus__FINEST = All PUs completed. Terminating Annotators and Cleaning Up. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_engine_stopped__FINEST = Engine Stopped. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_destroy_thread_group__FINEST = DESTROYING THREAD GROUP. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_thread__FINEST = Thread Info. \
-	(Thread Name: {0}) Thread Index: {1} CPE Thread Name: {2}
+  (Thread Name: {0}) Thread Index: {1} CPE Thread Name: {2}
 
 UIMA_CPM_stop_containers__FINEST = Stopping Containers. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_container_time__FINEST = Container Processing Time. \
-	(Thread Name: {0}) Container Name: {1} Total Time in Container: {2}
+  (Thread Name: {0}) Container Name: {1} Total Time in Container: {2}
 
 UIMA_CPM_stop_container__FINEST = Stopping Container. \
-	(Thread Name: {0}) Container Name: {1}
+  (Thread Name: {0}) Container Name: {1}
 
 UIMA_CPM_release_tcas__FINEST = TCAS list member is null. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_call_get_cas__FINEST = Calling casPool.getCas(0). \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_call_get_cas_returns__FINEST = Done Calling casPool.getCas(0). \
-	(Thread Name: {0}) Is CAS NULL: {1}
-	
+  (Thread Name: {0}) Is CAS NULL: {1}
+  
 UIMA_CPM_use_custom_timer__FINEST = Using Custom Timer to Measure Performance. \
-	(Thread Name: {0}) Timer class: {1}
-	
+  (Thread Name: {0}) Timer class: {1}
+  
 UIMA_CPM_use_default_timer__FINEST = Using Default Timer to Measure Performance. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_unhandled_error__SEVERE = The CPM thread group caught the following unhandled error: {1} \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_checkpoint_target_not_defined__FINEST = DebugControlThread- Target To Checkpoint not defined. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_invalid_cpm_instance__FINEST = DebugControlThread -CPM instance not valid - Null. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_thread_terminating__FINEST = Thread Terminating. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_disabling_key__FINEST = Disabling Key. \
-	(Thread Name: {0}) Key: {1} Value: {2}
+  (Thread Name: {0}) Key: {1} Value: {2}
 
 UIMA_CPM_enabling_key__FINEST =  Enabling Key. \
-	(Thread Name: {0}) Key: {1} Value: {2}
-	
+  (Thread Name: {0}) Key: {1} Value: {2}
+  
 UIMA_CPM_show_access_control_file__FINEST = Control File. \
-	(Thread Name: {0}) File Name: {1}
-	
+  (Thread Name: {0}) File Name: {1}
+  
 UIMA_CPM_access_control_file_not_found__FINEST = Control File Not Found. \
-	(Thread Name: {0}) File Name: {1}
-	
+  (Thread Name: {0}) File Name: {1}
+  
 UIMA_CPM_initialize_pipeline__FINEST = Initializing Processing Unit. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
-	
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  
 UIMA_CPM_timer_class__FINEST = Timer class for this run. \
-	(Thread Name: {0}) Timer Class Name: {1}
-	
+  (Thread Name: {0}) Timer Class Name: {1}
+  
 UIMA_CPM_disabled_cp__FINEST = Request to disable CasProcessor. \
-	(Thread Name: {0}) Cas Processor Name: {1} has been disabled.
-	
+  (Thread Name: {0}) Cas Processor Name: {1} has been disabled.
+  
 UIMA_CPM_enabled_cp__FINEST = Enabling CasProcessor. \
-	(Thread Name: {0}) Cas Processor Name: {1} has been enabled.
-	
+  (Thread Name: {0}) Cas Processor Name: {1} has been enabled.
+  
 UIMA_CPM_start_analysis__FINEST = Starting Analysis. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_invalid_cas_reference__SEVERE = An invalid CAS reference (CAS=NULL) was passed. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_entering_pipeline__FINEST = Entering Pipeline. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_retrieve_container__FINEST = Getting Next Container. \
-	(Thread Name: {0}) Container Index: {1}
-	
-	
+  (Thread Name: {0}) Container Index: {1}
+  
+  
 UIMA_CPM_pausing_cr__FINEST = Pausing ArtifactProducer Thread . \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_pausing_pp__FINEST = Pausing Processing Pipeline . \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_resuming_pp__FINEST = Resuming Processing Pipeline . \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_resume_cr__FINEST = Resuming ArtifactProducer Thread . \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_call_hasnext__FINEST = Calling CR.hasNext(). \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_get_cas_from_cr__FINEST = Getting Next Cas from CR. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_place_cas_in_queue__FINEST = Enqueuing CAS Bundle onto work queue. \
-	(Thread Name: {0}) CAS bundle size: {1}
-	
+  (Thread Name: {0}) CAS bundle size: {1}
+  
 UIMA_CPM_placed_cas_in_queue__FINEST = Enqueued CAS Bundle onto work queue. \
-	(Thread Name: {0}) CAS bundle size: {1}
+  (Thread Name: {0}) CAS bundle size: {1}
 
 UIMA_CPM_terminate_cr_thread__FINEST = Terminating CollectionReader Thread. \
-	(Thread Name: {0}). CPM is in shutdown state.
+  (Thread Name: {0}). CPM is in shutdown state.
 
 UIMA_CPM_processed_all__FINEST = CollectionReader has no more entities to process. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_end_of_processing__FINEST = End of Processing Reached. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_show_cpm_running_status__FINEST = Show CPM Running State. \
-	(Thread Name: {0}) CPM is running: {1}
+  (Thread Name: {0}) CPM is running: {1}
 
 UIMA_CPM_enqueue_eof_token__FINEST = Placing EOF Token on the Work Queue. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_done_enqueue_eof_token__FINEST = Done Placing EOF Token on the Work Queue. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_got_eof_token__FINEST = EOF Token Found Terminating ProcessingUint. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 
 
 
 
 UIMA_CPM_entering_queue__FINEST = Entering enqueue(). \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_queue_full__FINEST = Queue is full. Waiting ... \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_adding_cas_to_queue__FINEST = adding CAS to QUEUE. \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_cas_in_queue__FINEST = Cas added to queue. \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_enter_dequeue__FINEST = Entering dequeue(). \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_cas_dequeued__FINEST = Cas bundle dequeued from queue. \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_no_cas_dequeued__FINEST = No data in the queue. \
-	(Thread Name: {0}) Queue Name: {1} 
+  (Thread Name: {0}) Queue Name: {1} 
 
 UIMA_CPM_return_from_dequeue__FINEST = Returning from dequeue. \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_queue_empty__FINEST = Queue Empty. \
-	(Thread Name: {0}) Queue Name: {1} Will wait until notified.
+  (Thread Name: {0}) Queue Name: {1} Will wait until notified.
 
 UIMA_CPM_queue_notified__FINEST = Queue notified. New data available. \
-	(Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
 
 UIMA_CPM_add_cas_to_checkedout_list__FINEST = Added CAS to the Checked Out List. \
-	(Thread Name: {0}) Current List Size: {1}
+  (Thread Name: {0}) Current List Size: {1}
 
 UIMA_CPM_invalid_checkin__WARNING = An attempt is being made to return a CAS to a pool from which it was not checked out. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_removed_from_checkedout_list__FINEST = Removed CAS from the Checked Out List. \
-	(Thread Name: {0}) Current List Size: {1}
+  (Thread Name: {0}) Current List Size: {1}
 
 UIMA_CPM_return_cas_to_pool__FINEST = Done Returning Cas Back To Pool. \
-	(Thread Name: {0}) Current List Size: {1}
+  (Thread Name: {0}) Current List Size: {1}
 
 UIMA_CPM_single_threaded_mode__CONFIG = Running CPE in single-threaded mode. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_multi_threaded_mode__CONFIG = Running CPE in multi-threaded mode. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_show_cr_state__INFO = The collection reader thread state is: {1} \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_show_pu_state__INFO = The CPM processing unit is {1} and processing state {2}. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_show_cc_state__INFO = The CAS consumer thread state is {1}. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_killing_cpm__INFO = The application stopped the CPM. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_killing_cpm__WARNING = The application stopped the CPM. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_stop_cpm__WARNING = Processing the request to stop the CPM. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_asynch_stop_cpm__WARNING = Processing an asynchronous request to stop the CPM. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_cpm_stopped__FINEST = Stopped CPM Engine. Notifying Listeners. \
-	(Thread Name: {0}) Killed: {1}
+  (Thread Name: {0}) Killed: {1}
 
 UIMA_CPM_terminate_pipelines__INFO = The CPM engine is stopping. An end-of-file token is added to the worker queue. \
-	(Thread Name: {0}) Forced stop: {1}
+  (Thread Name: {0}) Forced stop: {1}
 
 UIMA_CPM_already_stopped__FINEST = Engine Already stopped. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_consuming_queue__FINEST = Consuming queue... \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_wait_consuming_queue__FINEST = Waiting for PU to consume queue. \
-	(Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
 
 UIMA_CPM_done_consuming_queue__FINEST = Done consuming queues. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_stop_processors__FINEST = Stopping CasProcessors. \
-	(Thread Name: {0}) PU index: {1}
+  (Thread Name: {0}) PU index: {1}
 
 UIMA_CPM_exception_during_cp_stop__WARNING = The CAS processors in container {1} cannot be stopped. \
-	(Thread Name: {0}) Reason: {2}
+  (Thread Name: {0}) Reason: {2}
 
 UIMA_CPM_stop_ccs__FINEST = Terminating CasConsumers and Cleaning Up . \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_stop_cpm__FINEST = Stopping CPM. Placing EOF Token on the Worker Queue. \
-	(Thread Name: {0}) Killed: {1}
+  (Thread Name: {0}) Killed: {1}
 
 UIMA_CPM_invalid_processor_configuration__SEVERE = The CAS processor configuration cannot be found in the CPE factory. \
-	(Thread Name: {0}) Lookup Key: {1}
+  (Thread Name: {0}) Lookup Key: {1}
 
 UIMA_CPM_add_consumer_to_list__CONFIG = Adding New Consumer to Existing Consumer List. \
-	(Thread Name: {0}) Consumer Name: {1}
+  (Thread Name: {0}) Consumer Name: {1}
 
 UIMA_CPM_add_consumer_to_new_list__CONFIG = Adding New Consumer to New Consumer List. \
-	(Thread Name: {0}) Consumer Name: {1}
+  (Thread Name: {0}) Consumer Name: {1}
 
 UIMA_CPM_add_pcp_to_existing_list__CONFIG = Adding New Parallelizable Cas Processor to existing List. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_add_pcp_to_new_list__CONFIG = Adding New Parallelizable Cas Processor to New Processor List. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_diabled_cp__FINEST = Request to disable CasProcessor succeeded. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_enabled_cp__FINEST = Re-enabled Cas Proceesor. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_invoke_cp_process__FINEST = Invoking process on Cas Processor. \
-	(Thread Name: {0}) Container: {1} Cas Processor Name: {2}
+  (Thread Name: {0}) Container: {1} Cas Processor Name: {2}
 
 UIMA_CPM_casobject_class__FINEST = CasObject Class. \
-	(Thread Name: {0}) Container: {1} CasObject Class Name: {2}
+  (Thread Name: {0}) Container: {1} CasObject Class Name: {2}
 
 UIMA_CPM_expected_casdata_class__FINEST = Expected CasData Instance. \
-	(Thread Name: {0}) Container: {1} Got: {2} Instead.
+  (Thread Name: {0}) Container: {1} Got: {2} Instead.
 
 
 
@@ -1124,241 +1124,241 @@ UIMA_CPM_expected_casdata_class__FINEST = Expected CasData Instance. \
 
 
 UIMA_CPM_exception_when_checkpointing__FINEST = Exception While Generating Checkpoint. \
-	(Thread Name: {0}) Message: {1}
+  (Thread Name: {0}) Message: {1}
 
 
 UIMA_CPM_checkpoint_with_synchpoint__FINEST = checkpointing with SynchPoint. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_checkpoint_with_pt__FINEST = checkpointing with Process Trace. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 
 UIMA_CPM_restoring_from_checkpoint__FINEST = Restoring from Checkpoint. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_synchpoint_from_file__FINEST = Retrieving SynchPoint from File. \
-	(Thread Name: {0}) Synchpoint File: {1}
+  (Thread Name: {0}) Synchpoint File: {1}
 
 UIMA_CPM_sleep__FINEST = Sleeping. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_wakeup__FINEST = Wakeing up. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_checkpoint__FINEST = Checkpoint. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_stop_checkpoint_thread__INFO = The CPM checkpoint thread stopped. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_paused__FINEST = CPM Paused. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_resumed__FINEST = CPM Resumed. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_stopped__FINEST = CPM Stopped. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_filter_enabled_left_part__FINEST = No right Operand. LeftPart Exists. \
-	(Thread Name: {0}) Component Name: {1} Left Part: {2} Has Left Part? : {3}
+  (Thread Name: {0}) Component Name: {1} Left Part: {2} Has Left Part? : {3}
 
 
 UIMA_CPM_filter_false__FINEST = Filter evaluates false. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_container_paused__FINEST = Container in Pause State. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_resuming_container__FINEST = Resuming Container After Sleep. \
-	(Thread Name: {0}) Component Name: {1} Slept for: {2}
+  (Thread Name: {0}) Component Name: {1} Slept for: {2}
 
 UIMA_CPM_wait_no_processor__FINEST = Waiting for valid (non-null) Cas Processor. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_destroy_processor__FINEST = Destroying CasProcessor Instance. \
-	(Thread Name: {0}) Component Name: {1} 
-	
+  (Thread Name: {0}) Component Name: {1} 
+  
 UIMA_CPM_failed_waiting_for_processor__SEVERE = An error occurred while waiting for the CAS processor {1}. \
-	(Thread Name: {0}) Reason: {2}
+  (Thread Name: {0}) Reason: {2}
 
 UIMA_CPM_show_cp_action_on_error__FINEST = Cas Processor Action On Error. \
-	(Thread Name: {0}) Component Name: {1} Action: {2}
-	
+  (Thread Name: {0}) Component Name: {1} Action: {2}
+  
 UIMA_CPM_action_on_error_not_defined__SEVERE = The ''action'' attribute of the <errorRateThreshold> element in component {1} is not defined. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_show_cp_proxy_pool_size__FINEST = Proxy Pool Size. \
-	(Thread Name: {0}) Component Name: {1} Pool Size: {2}
+  (Thread Name: {0}) Component Name: {1} Pool Size: {2}
 
 UIMA_CPM_cp_configuration_not_defined__SEVERE = The configuration of CAS processor {1} is not defined correctly in the CPE descriptor. \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_no_proxies__SEVERE = The CAS processor proxies for component {1} cannot be acquired. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_cp_deployment_mode_not_defined__SEVERE = The CAS processor deployment mode [integrated|local|remote] in component {1} cannot be determined. Check the CPE descriptor. \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_cp_failed_to_start__SEVERE = The CPM cannot be started. \
-	(Thread Name: {0}) Reason: {1}
-	
+  (Thread Name: {0}) Reason: {1}
+  
 UIMA_CPM_reduce_pipelines__CONFIG = Reducing Number of Processing Pipelines due to insufficient number of exclusive services. \
-	(Thread Name: {0}) Component Name: {1}
+  (Thread Name: {0}) Component Name: {1}
 
 UIMA_CPM_initialize_pipeline__FINEST = Intializing Processing Pipeline. \
-	(Thread Name: {0}) Pipeline Index: {1}
-	
+  (Thread Name: {0}) Pipeline Index: {1}
+  
 UIMA_CPM_pipeline_impl_class__FINEST = Processing Pipeline Class. \
-	(Thread Name: {0}) Pipeline Impl Class: {1}
-	
+  (Thread Name: {0}) Pipeline Impl Class: {1}
+  
 UIMA_CPM_started_pipelines__FINEST = Started All Processing Pipelines. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_join_threads__FINEST = Joining Threads. \
-	(Thread Name: {0})
-	
+  (Thread Name: {0})
+  
 UIMA_CPM_cr_thread_completed__FINEST = Collection Reader Thread Completed. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_join_pu__FINEST = Joining Processing Pipeline. \
-	(Thread Name: {0}) Pipeline: {1} Index: {2}
-	
+  (Thread Name: {0}) Pipeline: {1} Index: {2}
+  
 UIMA_CPM_join_pu_complete__FINEST = Processing Pipeline Thread Completed. \
-	(Thread Name: {0}) Pipeline: {1} Index: {2}
+  (Thread Name: {0}) Pipeline: {1} Index: {2}
 
 UIMA_CPM_join_cc__FINEST = Joining Cas Consumer Thread. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_join_cc_completed__FINEST = CasConsumer Thread completed. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_exception_converting_CAS__WARNING = The CAS cannot be converted. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_release_cas_from_cache__FINEST = Releasing CAS from local Cache. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_release_cas_from_cache_done__FINEST = Done releasing CAS from local Cache. \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_exception_releasing_cas__SEVERE = The Common Analysis Structures in container {1} cannot be released. \
-	(Thread Name: {0}) 
-	
+  (Thread Name: {0}) 
+  
 UIMA_CPM_releasing_cases__FINEST = Releasing CASes . \
-	(Thread Name: {0}) Container Name: {1} Release CAS: {2} Last Cas Processor: {3}
-	
+  (Thread Name: {0}) Container Name: {1} Release CAS: {2} Last Cas Processor: {3}
+  
 UIMA_CPM_done_releasing_cases__FINEST = Done releasing CASes . \
-	(Thread Name: {0}) Container Name: {1} 
+  (Thread Name: {0}) Container Name: {1} 
 
 
 UIMA_CPM_max_restart_reached__FINEST = Max restart Count reached. \
-	(Thread Name: {0}) Component Name: {1} Max Threshold: {2}
+  (Thread Name: {0}) Component Name: {1} Max Threshold: {2}
 
 UIMA_CPM_terminate_due_to_action__SEVERE = The CPM is stopped, because the current CAS processor generated too many errors. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_disable_due_to_action__FINEST = Disabling Cas Processor due to configured action. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_kill_pipeline__FINEST = Killing Pipeline Thread. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_kill_cp__FINEST = Killing Cas Processor . \
-	(Thread Name: {0}) Cas Processor Name: {1} 
+  (Thread Name: {0}) Cas Processor Name: {1} 
 
 UIMA_CPM_container_status__FINEST = Container Status. \
-	(Thread Name: {0}) Container: {1} Status: {2} 
+  (Thread Name: {0}) Container: {1} Status: {2} 
 
 UIMA_CPM_undeploy_cp_instances__FINEST = Undeploy Cas Processors. \
-	(Thread Name: {0}) Container: {1} Deployer Class Name: {2}
+  (Thread Name: {0}) Container: {1} Deployer Class Name: {2}
 
 
 UIMA_CPM_skip_CAS__FINEST = Skipping CAS and moving on based on action associated with this annotator. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_force_reconnect__FINEST = Throwing ServiceConnectionException to force reconnect. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_other_exception__FINEST = Other Exception. \
-	(Thread Name: {0}) Component Name: {1} Exception Name: {2}
+  (Thread Name: {0}) Component Name: {1} Exception Name: {2}
 
 UIMA_CPM_no_resource_exception__FINEST = Not ResourceProcessException. \
-	(Thread Name: {0}) Component Name: {1} Exception: {2}
+  (Thread Name: {0}) Component Name: {1} Exception: {2}
 
 UIMA_CPM_abort_exceeded_error_threshold__SEVERE = The CPM stopped because the configured error threshold {2} was exceeded. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_disable_exceeded_error_threshold__SEVERE = The CAS processor is disabled because the configured error threshold {2} was exceeded. \
-	(Thread Name: {0}) Component Name: {1} 
+  (Thread Name: {0}) Component Name: {1} 
 
 UIMA_CPM_skipping_cas__FINEST = Skipping Cas. \
-	(Thread Name: {0}) Component Name: {1}
+  (Thread Name: {0}) Component Name: {1}
 
 
 UIMA_CPM_log_docid__FINEST = Logging DocID. \
-	(Thread Name: {0}) Container Name: {1} Doc ID: {2} 
+  (Thread Name: {0}) Container Name: {1} Doc ID: {2} 
 
 UIMA_CPM_max_restart_action__FINEST = Cas Processor max restart action. \
-	(Thread Name: {0}) Cas Processor Name: {1} action:{2}
+  (Thread Name: {0}) Cas Processor Name: {1} action:{2}
 
 UIMA_CPM_show_docs_to_process__CONFIG = Number of Documents to Process. \
-	(Thread Name: {0}) Doc Count: {1}
+  (Thread Name: {0}) Doc Count: {1}
 
 UIMA_CPM_show_start_doc_id__FINEST = Begin Processing with Entity Id. \
-	(Thread Name: {0}) Doc ID: {1}
+  (Thread Name: {0}) Doc ID: {1}
 
 UIMA_CPM_dequeued_artifact__FINEST = Dequeued Next Artifact from Queue. \
-	(Thread Name: {0}) Queue Name: {1}
+  (Thread Name: {0}) Queue Name: {1}
 
 UIMA_CPM_show_cp_filter__FINEST = CP Filter Expression. \
-	(Thread Name: {0}) Cas Processor Name: {1} Filter Expression: {2}
+  (Thread Name: {0}) Cas Processor Name: {1} Filter Expression: {2}
 
 UIMA_CPM_show_cp_deploy_params__FINEST = Show CP Deploy Param. \
-	(Thread Name: {0}) Cas Processor Name: {1} Deploy Param Name:{2} Deploy Param Value:{3}
+  (Thread Name: {0}) Cas Processor Name: {1} Deploy Param Name:{2} Deploy Param Value:{3}
  
 UIMA_CPM_config_non_java_service__FINEST = Configuring Non-Java Application. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_cp_failure_sample_size__FINEST = failureThresholdSample configuration. \
-	(Thread Name: {0}) Cas Processor Name: {1} error Sample Size: {2}
+  (Thread Name: {0}) Cas Processor Name: {1} error Sample Size: {2}
 
 UIMA_CPM_config_java_service__FINEST = Configuring Java Application. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_service_rejected_requested__WARNING = The service {1} rejected an invalid request. Reason code: {2} \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_request_metadata__FINEST = Requesting Metadata. \
-	(Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_return_meta__FINEST = Returning Metadata from Service. \
-	(Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_done_parsing_meta__FINEST = Done Parsing Metadata. \
-	(Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_send_batch_complete__FINEST = Sending Batch Complete to Service. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}
-	
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}
+  
 UIMA_CPM_send_collection_complete__FINEST = Sending Collection Complete to Service. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}	 
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}  
 
 UIMA_CPM_time_spent_serializing_xcas__FINEST = Total Time Spent Serializing to XCAS. \
-	(Thread Name: {0}) Time: {1}	 
+  (Thread Name: {0}) Time: {1}   
 
 UIMA_CPM_time_spent_deserializing_xcas__FINEST = Total Time Spent Deserializing to XCAS. \
-	(Thread Name: {0}) Time: {1}	 
-	
+  (Thread Name: {0}) Time: {1}   
+  
 UIMA_CPM_time_spent_in_transit__FINEST = Total Round-Trip Time (Send-Analyze-Receive). \
-	(Thread Name: {0}) Time: {1}	 
+  (Thread Name: {0}) Time: {1}   
 
 UIMA_CPM_sending_process_req__FINEST = Sending Process Request to Service. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} Timeout: {3}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} Timeout: {3}
 
 UIMA_CPM_stopping_service__INFO = The service application stopped. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2} CMD: {3}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2} CMD: {3}
 
 UIMA_CPM_vns_not_provided__SEVERE = The VNS_HOST or VNS_PORT are not initialized. \
 (Thread Name: {0})
@@ -1368,89 +1368,89 @@ UIMA_CPM_locating_service__FINEST = Resolving service. \
 
 
 UIMA_CPM_connection_validated__FINEST = Connection to service is working. Received Metadata. \
-	(Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread Name: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_killing_process_failed__WARNING = A process with PID {1} cannot be stopped. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_deploying_cp__FINEST = Deploying CasProcessor. \
-	(Thread Name: {0}) CP name: {1} 
+  (Thread Name: {0}) CP name: {1} 
 
 UIMA_CPM_producing_cas_consumer__FINEST = Producing Cas Consumer. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_producing_cas_data_consumer__FINEST = Producing Cas Data Consumer. \
-	(Thread Name: {0}) 
+  (Thread Name: {0}) 
 
 UIMA_CPM_add_cp__CONFIG = Adding CasProcessor. \
-	(Thread Name: {0}) Cas Processor Name: {1}
+  (Thread Name: {0}) Cas Processor Name: {1}
 
 UIMA_CPM_add_cp_with_index__FINEST = Adding New Cas Processor. \
-	(Thread Name: {0}) CP Name: {1} Appending to list. List length: {2}
+  (Thread Name: {0}) CP Name: {1} Appending to list. List length: {2}
 
 UIMA_CPM_show_cp_deployment__FINEST = Cas Processor Deployment Mode. \
-	(Thread Name: {0}) CP Name: {1} Deployment Mode: {2}
+  (Thread Name: {0}) CP Name: {1} Deployment Mode: {2}
 
 UIMA_CPM_add_cp_from_list__FINEST = Adding New CasProcessors from the List. \
-	(Thread Name: {0}) CP Name: {1}
+  (Thread Name: {0}) CP Name: {1}
 
 UIMA_CPM_create_new_cp_from_list__FINEST = Creating New CasProcessors from the List. \
-	(Thread Name: {0}) CP Name: {1}
+  (Thread Name: {0}) CP Name: {1}
 
 UIMA_CPM_show_os__FINEST = Operating System. \
-	(Thread Name: {0}) OS: {1}
+  (Thread Name: {0}) OS: {1}
 
 UIMA_CPM_show_cmd_classpath__FINEST = Split classpath. \
-	(Thread Name: {0}) Current Classpath: {1}
+  (Thread Name: {0}) Current Classpath: {1}
 
 UIMA_CPM_deploying_cp__FINEST = Redeploying CasProcessor. \
-	(Thread Name: {0}) CP name: {1} 
+  (Thread Name: {0}) CP name: {1} 
 
 UIMA_CPM_deploying_new_cp__CONFIG = Deploying CasProcessor. \
-	(Thread Name: {0}) CP name: {1} 
+  (Thread Name: {0}) CP name: {1} 
 
 UIMA_CPM_cp_deployment__FINEST =  CP Deployment. \
-	(Thread Name: {0}) Deployment Mode: {1} 
+  (Thread Name: {0}) Deployment Mode: {1} 
 
 UIMA_CPM_show_cmd_arg__FINEST = Current Arg. \
-	(Thread Name: {0}) Arg Index: {1} Arg Value: {2} 
+  (Thread Name: {0}) Arg Index: {1} Arg Value: {2} 
 
 UIMA_CPM_lookup_cp__FINEST = Retrieving CasProcessor Configuration from CPEFactory. \
-	(Thread Name: {0}) CP name: {1} 
+  (Thread Name: {0}) CP name: {1} 
 
 
 UIMA_CPM_cp_no_name__SEVERE = The name of the CAS processor cannot be retrieved because the meta data cannot be accessed. \
-	(Thread Name: {0}).
+  (Thread Name: {0}).
 
 UIMA_CPM_reducing_cp_instance_count__FINEST = Reducing number of Cas Processor pool instances due to not enough services. \
-	(Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_invalid_cpe_descriptor__SEVERE = The CPE descriptor for the CAS processor {1} is invalid because element {2} cannot be found. \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_launching_with_service_cmd__FINEST = Launching Cas Processor Application \
-	(Thread Name: {0}) Cas Processor Name: {1} Command Line Argument: {2} Value: {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Command Line Argument: {2} Value: {3}
 
 UIMA_CPM_launching_with_service_exec__FINEST = Launching Cas Processor Application \
-	(Thread Name: {0}) Cas Processor Name: {1} Exec Argument: {2} Value: {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Exec Argument: {2} Value: {3}
 
 UIMA_CPM_launching_with_service_env__FINEST = Launching Cas Processor Application \
-	(Thread Name: {0}) Cas Processor Name: {1} Environment: {2} Value: {3}
+  (Thread Name: {0}) Cas Processor Name: {1} Environment: {2} Value: {3}
 
 UIMA_CPM_connecting_to_services__FINEST = Connecting to Launched Services. \
-	(Thread Name: {0}) Cas Processor Name: {1} 
+  (Thread Name: {0}) Cas Processor Name: {1} 
 
 UIMA_CPM_unsupported_deploy_mode__SEVERE = The deployment mode {2} for the CAS processor {1} is not supported. Define the deployment mode as local, integrated or remote \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_deploy_vns__FINEST = Deploying Internal VNS: \
-	(Thread Name: {0})
+  (Thread Name: {0})
 
 UIMA_CPM_deploy_vns_redeploy__FINEST = Deploying Internal VNS: \
-	(Thread Name: {0}) Redeploy Flag: {1} Restart Count: {2}
+  (Thread Name: {0}) Redeploy Flag: {1} Restart Count: {2}
 
 UIMA_CPM_undeploying_service__FINEST = Undeploying Service: \
-	(Thread Name: {0}) Service Name: {1} Service Port: {2}
+  (Thread Name: {0}) Service Name: {1} Service Port: {2}
 
 UIMA_CPM_service_deployed__FINEST = Service Deployed \
   (Thread Name: {0}) Service Name: {1}
@@ -1483,4 +1483,6 @@ UIMA_CPM_redeploy_cp_done__FINEST = Done redeploying CasProcessor. \
   (Thread Name: {0}) Container: {1} Cas Processor: {2}
 
 UIMA_CPM_pipeline_exception__FINEST = The container {1} experienced an error. Is container paused: {2} \
-	(Thread Name: {0})   
+  (Thread Name: {0})
+  
+UIMA_CPM_unknown_thread__WARNING = Resource leak: detected non-UIMA thread [{0}] in CPM Thread Group which appears to be preventing the thread group to shut down. This message appears only once per thread!


### PR DESCRIPTION
- Factor ThreadGroupDestroyer out into a static inner class to avoid the reference on the CPMEngine
- Log a warning when a non-CPE thread is preventing the CPM thread group from shutting down
- Auto-formatting