### PR TITLE
[UIMA-6412] Stop using ThreadGroup in CPMEngine

### DIFF
--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/Checkpoint.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/Checkpoint.java
@@ -88,13 +88,6 @@ public class Checkpoint implements Runnable {
   }
 
   /**
-   * Start the thread.
-   */
-  public void start() {
-    new Thread(this).start();
-  }
-
-  /**
    * Stops the checkpoint thread.
    */
   public void stop() {

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ArtifactProducer.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ArtifactProducer.java
@@ -63,7 +63,7 @@ import org.apache.uima.util.impl.ProcessTrace_impl;
  * 
  * 
  */
-public class ArtifactProducer extends Thread {
+public class ArtifactProducer implements Runnable {
 
   /** The thread state. */
   public int threadState = 0;

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ArtifactProducer.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ArtifactProducer.java
@@ -49,7 +49,6 @@ import org.apache.uima.util.Progress;
 import org.apache.uima.util.UimaTimer;
 import org.apache.uima.util.impl.ProcessTrace_impl;
 
-
 /**
  * Component responsible for continuously filling a work queue with bundles containing Cas'es. The
  * queue is shared with a Processing Pipeline that consumes bundles of Cas. As soon as the the
@@ -65,7 +64,7 @@ import org.apache.uima.util.impl.ProcessTrace_impl;
  * 
  */
 public class ArtifactProducer extends Thread {
-  
+
   /** The thread state. */
   public int threadState = 0;
 
@@ -123,7 +122,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Instantiates and initializes this instance.
    *
-   * @param acpm the acpm
+   * @param acpm
+   *          the acpm
    */
   public ArtifactProducer(CPMEngine acpm) {
     cpm = acpm;
@@ -135,10 +135,10 @@ public class ArtifactProducer extends Thread {
   /**
    * Construct instance of this class with a reference to the cpe engine and a pool of cas'es.
    * 
-   * @param acpm -
-   *          reference to the cpe
-   * @param aPool -
-   *          pool of cases
+   * @param acpm
+   *          - reference to the cpe
+   * @param aPool
+   *          - pool of cases
    */
   public ArtifactProducer(CPMEngine acpm, CPECasPool aPool) {
     cpm = acpm;
@@ -160,8 +160,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Plug in Custom Timer to time events.
    *
-   * @param aTimer -
-   *          custom timer
+   * @param aTimer
+   *          - custom timer
    */
   public void setUimaTimer(UimaTimer aTimer) {
     timer = aTimer;
@@ -170,7 +170,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Sets the process trace.
    *
-   * @param aProcTrace the new process trace
+   * @param aProcTrace
+   *          the new process trace
    */
   public void setProcessTrace(ProcessTrace aProcTrace) {
     globalSharedProcessTrace = aProcTrace;
@@ -208,8 +209,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Assign total number of entities to process.
    *
-   * @param aNumToProcess -
-   *          number of entities to read from the Collection Reader
+   * @param aNumToProcess
+   *          - number of entities to read from the Collection Reader
    */
   public void setNumEntitiesToProcess(long aNumToProcess) {
     maxToProcess = aNumToProcess;
@@ -218,8 +219,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Assign CollectionReader to be used for reading.
    *
-   * @param aCollectionReader -
-   *          collection reader as source of data
+   * @param aCollectionReader
+   *          - collection reader as source of data
    */
   public void setCollectionReader(BaseCollectionReader aCollectionReader) {
     collectionReader = aCollectionReader;
@@ -228,15 +229,15 @@ public class ArtifactProducer extends Thread {
       // Determines how many at a time this Collection Reader will return
       // for each fetch
       readerFetchSize = (Integer) collectionReader.getProcessingResourceMetaData()
-          .getConfigurationParameterSettings().getParameterValue("fetchSize");
+              .getConfigurationParameterSettings().getParameterValue("fetchSize");
     }
   }
 
   /**
    * Assigns a queue where the artifacts produced by this component will be deposited.
    *
-   * @param aQueue -
-   *          queue for the artifacts this class is producing
+   * @param aQueue
+   *          - queue for the artifacts this class is producing
    */
   public void setWorkQueue(BoundedWorkQueue aQueue) {
     workQueue = aQueue;
@@ -246,7 +247,8 @@ public class ArtifactProducer extends Thread {
    * Add table that will contain statistics gathered while reading entities from a Collection This
    * table is used for non-uima reports.
    *
-   * @param aStatTable the new CPM stat table
+   * @param aStatTable
+   *          the new CPM stat table
    */
   public void setCPMStatTable(Map aStatTable) {
     cpmStatTable = aStatTable;
@@ -276,7 +278,8 @@ public class ArtifactProducer extends Thread {
    * optimizing processing. When pipelines start up there are already entities in the work queue to
    * process.
    *
-   * @throws Exception the exception
+   * @throws Exception
+   *           the exception
    */
   public void fillQueue() throws Exception {
     // Create an array holding CAS'es. Configuration of the Reader may
@@ -309,14 +312,10 @@ public class ArtifactProducer extends Thread {
           // determines how many entities to return for each fetch.
           casObjectList = readNext(readerFetchSize);
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            UIMAFramework.getLogger(this.getClass()).logrb(
-                    Level.FINEST,
-                    this.getClass().getName(),
-                    "process",
-                    CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                    "UIMA_CPM_enqueue_cas_bundle__FINEST",
-                    new Object[] { Thread.currentThread().getName(),
-                        String.valueOf(casObjectList.length) });
+            UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
+                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                    "UIMA_CPM_enqueue_cas_bundle__FINEST", new Object[] {
+                        Thread.currentThread().getName(), String.valueOf(casObjectList.length) });
           }
           // Count number of entities fetched so far
           entityCount += casObjectList.length;
@@ -337,11 +336,8 @@ public class ArtifactProducer extends Thread {
         Progress[] progress = collectionReader.getProgress();
         if (progress != null) {
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            UIMAFramework.getLogger(this.getClass()).logrb(
-                    Level.FINEST,
-                    this.getClass().getName(),
-                    "process",
-                    CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+            UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
+                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
                     "UIMA_CPM_show_cr_progress__FINEST",
                     new Object[] { Thread.currentThread().getName(),
                         String.valueOf(progress[0].getCompleted()) });
@@ -359,9 +355,9 @@ public class ArtifactProducer extends Thread {
             notifyListeners((CAS) casObjectList[i], e);
             casPool.releaseCas(casList[i]);
             casList[i] = null;
-//            synchronized (casPool) {  // removed - redundant, because done as part of releaseCas
-//              casPool.notifyAll();
-//            }
+            // synchronized (casPool) { // removed - redundant, because done as part of releaseCas
+            // casPool.notifyAll();
+            // }
 
           } else {
             notifyListeners(null, e);
@@ -378,13 +374,15 @@ public class ArtifactProducer extends Thread {
    * Reads next set of entities from the CollectionReader. This method may return more than one Cas
    * at a time.
    *
-   * @param fetchSize the fetch size
+   * @param fetchSize
+   *          the fetch size
    * @return - The Object returned from the method depends on the type of the CollectionReader.
    *         Either CASData[] or CASObject[] initialized with document metadata and content is
    *         returned. If the CollectionReader has no more entities (EOF), null is returned.
-   * @throws IOException -
-   *           error while reading corpus
-   * @throws CollectionException -
+   * @throws IOException
+   *           - error while reading corpus
+   * @throws CollectionException
+   *           -
    * @parma fetchSize - number of entities the CollectionReader should return for each fetch. It is
    *        hint as the Collection Reader ultimately decides how many to return.
    */
@@ -419,18 +417,15 @@ public class ArtifactProducer extends Thread {
 
         threadState = 1001; // Waiting for CAS
         // Get the cas from the pool.
-        while (cpm.isRunning() && (casList[i] = casPool.getCas(0)) == null)
+        while (cpm.isRunning() && (casList[i] = casPool.getCas(0)) == null) {
           ; // intentionally empty while loop
+        }
 
         if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-          UIMAFramework.getLogger(this.getClass()).logrb(
-                  Level.FINEST,
-                  this.getClass().getName(),
-                  "process",
-                  CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                  "UIMA_CPM_cr_check_cas_for_null__FINEST",
-                  new Object[] { Thread.currentThread().getName(),
-                      String.valueOf((casList[i] == null)) });
+          UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
+                  "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                  "UIMA_CPM_cr_check_cas_for_null__FINEST", new Object[] {
+                      Thread.currentThread().getName(), String.valueOf((casList[i] == null)) });
         }
         if (cpm.isRunning() == false) {
           // CPM is in shutdown stage. No need to enqueue additional
@@ -444,9 +439,9 @@ public class ArtifactProducer extends Thread {
           for (int listCounter = 0; casList != null && casList[i] != null
                   && listCounter < casList.length; listCounter++) {
             casPool.releaseCas(casList[listCounter]);
-//            synchronized (casPool) { // redundant - releaseCas call does this
-//              casPool.notifyAll();
-//            }
+            // synchronized (casPool) { // redundant - releaseCas call does this
+            // casPool.notifyAll();
+            // }
           }
           if (cpmStatTable != null) {
             Progress[] progress = collectionReader.getProgress();
@@ -477,15 +472,16 @@ public class ArtifactProducer extends Thread {
         casList[i].reset();
 
         // If Collection Reader and CAS Initilaizer do not declare any
-        // output SofAs, must be passed the default view (meaning whatever's 
-        //mapped to _InitialView) for backward compatiblity
+        // output SofAs, must be passed the default view (meaning whatever's
+        // mapped to _InitialView) for backward compatiblity
         Capability[] capabilities;
         CasInitializer casIni = ((CollectionReader) collectionReader).getCasInitializer();
-        if (casIni != null)
+        if (casIni != null) {
           capabilities = casIni.getProcessingResourceMetaData().getCapabilities();
-        else
+        } else {
           capabilities = ((CollectionReader) collectionReader).getProcessingResourceMetaData()
                   .getCapabilities();
+        }
 
         boolean sofaUnaware = true;
         for (int j = 0; j < capabilities.length; j++) {
@@ -509,9 +505,9 @@ public class ArtifactProducer extends Thread {
             String absSofaName = context.getComponentInfo().mapToSofaID(CAS.NAME_DEFAULT_SOFA);
             if (!CAS.NAME_DEFAULT_SOFA.equals(absSofaName)) {
               casList[i].createView(CAS.NAME_DEFAULT_SOFA);
-            }            
+            }
             CAS view = casList[i].getView(CAS.NAME_DEFAULT_SOFA);
-            
+
             if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
               UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST,
                       this.getClass().getName(), "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
@@ -613,12 +609,12 @@ public class ArtifactProducer extends Thread {
         success = true;
       } finally {
         if (!success) {
-          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(),
-                  "Process", "failure");
+          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(), "Process",
+                  "failure");
 
         } else {
-          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(),
-                  "Process", "success");
+          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(), "Process",
+                  "success");
 
         }
         synchronized (globalSharedProcessTrace) {
@@ -660,6 +656,8 @@ public class ArtifactProducer extends Thread {
    */
   @Override
   public void run() {
+    Thread.currentThread().setName("[CollectionReader Thread]::");
+
     boolean crEventCompleted = false; // this flag is used to mark the
     // ProcessTrace event
     if (!cpm.isRunning()) {
@@ -680,8 +678,7 @@ public class ArtifactProducer extends Thread {
       placeEOFToken();
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
         UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                "UIMA_CPM_eof_marker_enqueued__FINEST",
+                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_eof_marker_enqueued__FINEST",
                 new Object[] { Thread.currentThread().getName() });
       }
       return;
@@ -725,18 +722,17 @@ public class ArtifactProducer extends Thread {
         threadState = 1004; // Entering hasNext()
 
         // start the CR event
-        localTrace.startEvent(collectionReader.getProcessingResourceMetaData().getName(),
-                "Process", "");
+        localTrace.startEvent(collectionReader.getProcessingResourceMetaData().getName(), "Process",
+                "");
         crEventCompleted = false;
         if (collectionReader.hasNext()) {
-          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(),
-                  "Process", "success");
+          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(), "Process",
+                  "success");
           crEventCompleted = true;
 
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
             UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                    "UIMA_CPM_get_cas_from_cr__FINEST",
+                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_get_cas_from_cr__FINEST",
                     new Object[] { Thread.currentThread().getName() });
           }
           casObjectList = readNext(readerFetchSize);
@@ -747,14 +743,15 @@ public class ArtifactProducer extends Thread {
                 ChunkMetadata meta = CPMUtils.getChunkMetadata((CAS) casObjectList[i]);
                 if (meta != null) {
                   if (timedoutDocs.containsKey(meta.getDocId())) {
-                    notifyListeners(casList[i], new ResourceProcessException(new SkipCasException(
-                            "Dropping CAS due chunk Timeout. Doc Id::" + meta.getDocId()
-                                    + " Sequence:" + meta.getSequence())));
+                    notifyListeners(casList[i],
+                            new ResourceProcessException(new SkipCasException(
+                                    "Dropping CAS due chunk Timeout. Doc Id::" + meta.getDocId()
+                                            + " Sequence:" + meta.getSequence())));
 
                     casPool.releaseCas((CAS) casObjectList[i]);
-//                    synchronized (casPool) {  // redundant, releaseCas call does this
-//                      casPool.notifyAll();
-//                    }
+                    // synchronized (casPool) { // redundant, releaseCas call does this
+                    // casPool.notifyAll();
+                    // }
                     releasedCas = true;
                   }
                 }
@@ -764,14 +761,10 @@ public class ArtifactProducer extends Thread {
               }
             }
             if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-              UIMAFramework.getLogger(this.getClass()).logrb(
-                      Level.FINEST,
-                      this.getClass().getName(),
-                      "process",
-                      CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                      "UIMA_CPM_place_cas_in_queue__FINEST",
-                      new Object[] { Thread.currentThread().getName(),
-                          String.valueOf(casObjectList.length) });
+              UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST,
+                      this.getClass().getName(), "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                      "UIMA_CPM_place_cas_in_queue__FINEST", new Object[] {
+                          Thread.currentThread().getName(), String.valueOf(casObjectList.length) });
             }
             // Prevent processing of new CASes if the CPM has been
             // killed hard. Allow processing of CASes
@@ -782,17 +775,14 @@ public class ArtifactProducer extends Thread {
                     || (cpm.isRunning() == false && cpm.isHardKilled() == false)) {
               threadState = 1005; // Entering enqueue
               workQueue.enqueue(casObjectList);
-//              synchronized (workQueue) { // redundant, enqueue does this
-//                workQueue.notifyAll();
-//              }
+              // synchronized (workQueue) { // redundant, enqueue does this
+              // workQueue.notifyAll();
+              // }
               threadState = 1006; // Done Entering enqueue
               entityCount += casObjectList.length;
               if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-                UIMAFramework.getLogger(this.getClass()).logrb(
-                        Level.FINEST,
-                        this.getClass().getName(),
-                        "process",
-                        CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST,
+                        this.getClass().getName(), "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
                         "UIMA_CPM_placed_cas_in_queue__FINEST",
                         new Object[] { Thread.currentThread().getName(),
                             String.valueOf(casObjectList.length) });
@@ -838,8 +828,8 @@ public class ArtifactProducer extends Thread {
       } catch (Exception e) {
         // The following conditional is true if hasNext() has failed
         if (!crEventCompleted) {
-          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(),
-                  "Process", "failure");
+          localTrace.endEvent(collectionReader.getProcessingResourceMetaData().getName(), "Process",
+                  "failure");
         }
         // e.printStackTrace();
         // changed from FINER to WARNING: https://issues.apache.org/jira/browse/UIMA-2440
@@ -859,9 +849,9 @@ public class ArtifactProducer extends Thread {
               notifyListeners(casList[i], e);
               casPool.releaseCas(casList[i]);
               casList[i] = null;
-//              synchronized (casPool) { // redundant, releaseCas does this
-//                casPool.notifyAll();
-//              }
+              // synchronized (casPool) { // redundant, releaseCas does this
+              // casPool.notifyAll();
+              // }
 
             } else {
               notifyListeners(null, e);
@@ -906,20 +896,21 @@ public class ArtifactProducer extends Thread {
   /**
    * Notify registered callback listeners of a given exception.
    *
-   * @param aCas the a cas
-   * @param anException -
-   *          exception to propagate to callback listeners
+   * @param aCas
+   *          the a cas
+   * @param anException
+   *          - exception to propagate to callback listeners
    */
   private void notifyListeners(CAS aCas, Exception anException) {
     for (int i = 0; callbackListeners != null && i < callbackListeners.size(); i++) {
       StatusCallbackListener statCL = (StatusCallbackListener) callbackListeners.get(i);
-      if ( statCL != null ) {
+      if (statCL != null) {
         ProcessTrace prTrace = new ProcessTrace_impl(cpm.getPerformanceTuningSettings());
         EntityProcessStatusImpl aEntityProcStatus = new EntityProcessStatusImpl(prTrace);
         aEntityProcStatus.addEventStatus("Collection Reader Failure", "failed", anException);
         // Notify the listener that the Cas has been processed
         CPMEngine.callEntityProcessCompleteWithCAS(statCL, aCas, aEntityProcStatus);
-//        statCL.entityProcessComplete(aCas, aEntityProcStatus);
+        // statCL.entityProcessComplete(aCas, aEntityProcStatus);
       }
     }
   }
@@ -953,9 +944,9 @@ public class ArtifactProducer extends Thread {
                 new Object[] { Thread.currentThread().getName(), String.valueOf(cpm.isRunning()) });
 
       }
-//      synchronized (workQueue) { // redundant, the enqueue call above does this
-//        workQueue.notifyAll();
-//      }
+      // synchronized (workQueue) { // redundant, the enqueue call above does this
+      // workQueue.notifyAll();
+      // }
     } catch (Exception e) {
       e.printStackTrace();
       if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
@@ -983,7 +974,8 @@ public class ArtifactProducer extends Thread {
   /**
    * Invalidate.
    *
-   * @param aCasList the a cas list
+   * @param aCasList
+   *          the a cas list
    */
   public void invalidate(CAS[] aCasList) {
     for (int i = 0; aCasList != null && i < aCasList.length && aCasList[i] != null; i++) {

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/BoundedWorkQueue.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/BoundedWorkQueue.java
@@ -19,12 +19,17 @@
 
 package org.apache.uima.collection.impl.cpm.engine;
 
+import static java.lang.System.currentTimeMillis;
+
+import java.lang.invoke.MethodHandles;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.impl.cpm.utils.CPMUtils;
 import org.apache.uima.util.Level;
+import org.apache.uima.util.Logger;
 
 /**
  * Implementation of a Bounded Queue, a queue with a fixed number of slots. Used primarily to feed
@@ -39,12 +44,13 @@ import org.apache.uima.util.Level;
  * 
  */
 public class BoundedWorkQueue {
+  private static final Logger LOG = UIMAFramework.getLogger(MethodHandles.lookup().lookupClass());
 
   /** The queue max size. */
   protected final int queueMaxSize;
 
   /** The queue. */
-  protected LinkedList queue = new LinkedList();
+  protected List<Object> queue = new LinkedList<>();
 
   /** The number elements in queue. */
   protected int numberElementsInQueue = 0;
@@ -118,11 +124,12 @@ public class BoundedWorkQueue {
    */
   public synchronized void enqueue(Object anObject) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-              "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_entering_queue__FINEST",
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_entering_queue__FINEST",
               new Object[] { Thread.currentThread().getName(), queueName,
                   String.valueOf(numberElementsInQueue) });
     }
+
     // If the queue is full, just wait until someone dequeues something from the queue
     try {
       // Make an exception and allow EOFToken placement beyond the end of queue. Dont wait here. We
@@ -132,8 +139,8 @@ public class BoundedWorkQueue {
         // Block if the queue is full AND the CPE is running
         while (numberElementsInQueue == queueMaxSize && (cpm == null || cpm.isRunning())) {
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_full__FINEST",
+            LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+                    CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_full__FINEST",
                     new Object[] { Thread.currentThread().getName(), queueName,
                         String.valueOf(numberElementsInQueue) });
           }
@@ -144,21 +151,24 @@ public class BoundedWorkQueue {
     }
 
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-              "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_adding_cas_to_queue__FINEST",
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_adding_cas_to_queue__FINEST",
               new Object[] { Thread.currentThread().getName(), queueName,
                   String.valueOf(numberElementsInQueue) });
     }
-    // Appeand the object to the queue
+
+    // Append the object to the queue
     queue.add(anObject);
     // increment number of items in the queue
     numberElementsInQueue++;
+
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-              "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cas_in_queue__FINEST",
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cas_in_queue__FINEST",
               new Object[] { Thread.currentThread().getName(), queueName,
                   String.valueOf(numberElementsInQueue) });
     }
+
     notifyAll();
   }
 
@@ -169,8 +179,8 @@ public class BoundedWorkQueue {
    */
   public synchronized Object dequeue() {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-              "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_enter_dequeue__FINEST",
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_enter_dequeue__FINEST",
               new Object[] { Thread.currentThread().getName(), queueName,
                   String.valueOf(numberElementsInQueue) });
     }
@@ -184,21 +194,21 @@ public class BoundedWorkQueue {
     numberElementsInQueue--;
     if (returnedObject instanceof Object[]) {
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cas_dequeued__FINEST",
+        LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+                CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cas_dequeued__FINEST",
                 new Object[] { Thread.currentThread().getName(), queueName,
                     String.valueOf(((Object[]) returnedObject).length) });
       }
     } else {
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_no_cas_dequeued__FINEST",
+        LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+                CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_no_cas_dequeued__FINEST",
                 new Object[] { Thread.currentThread().getName(), queueName });
       }
     }
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-              "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_return_from_dequeue__FINEST",
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_return_from_dequeue__FINEST",
               new Object[] { Thread.currentThread().getName(), queueName,
                   String.valueOf(numberElementsInQueue) });
     }
@@ -217,6 +227,10 @@ public class BoundedWorkQueue {
    */
   public synchronized Object dequeue(long aTimeout) {
     Object resource = dequeue();
+    if (resource != null) {
+      return resource;
+    }
+
     // next 5 lines commented out - was old method of waiting. -- Jan 2008 MIS
     // changes include waiting a little (WAIT_TIMEOUT) if !cpm.isRunning, to prevent
     // 100% CPU utilization while waiting for existing processes to finish
@@ -227,36 +241,37 @@ public class BoundedWorkQueue {
     // long timeExpire = (0 == aTimeout)? Long.MAX_VALUE : (System.currentTimeMillis() + aTimeout +
     // 1);
     // long timeLeft = timeExpire - System.currentTimeMillis();
-    if (resource == null) {
-      try {
-        // add 1 millisecond to expire time to account for "rounding" issues
-        long timeNow = System.currentTimeMillis();
-        long timeExpire = (!cpm.isRunning()) ? timeNow + WAIT_TIMEOUT : // a value to avoid 100% cpu
-                ((0 == aTimeout) ? Long.MAX_VALUE : timeNow + aTimeout + 1);
-        long timeLeft = timeExpire - timeNow;
-        while (timeLeft > 0) {
-          if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_empty__FINEST",
-                    new Object[] { Thread.currentThread().getName(), queueName });
-          }
-          this.wait(timeLeft); // timeLeft is always > 0
-          resource = dequeue();
-          if (null != resource) {
-            return resource;
-          }
-          timeLeft = timeExpire - System.currentTimeMillis();
+    try {
+      // add 1 millisecond to expire time to account for "rounding" issues
+      long timeNow = currentTimeMillis();
+      long timeExpire = (!cpm.isRunning()) ? timeNow + WAIT_TIMEOUT : // a value to avoid 100% CPU
+              ((0 == aTimeout) ? Long.MAX_VALUE : timeNow + aTimeout + 1);
+      long timeLeft = timeExpire - timeNow;
+      while (timeLeft > 0) {
+        if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
+          LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+                  CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_empty__FINEST",
+                  new Object[] { Thread.currentThread().getName(), queueName });
         }
-      } catch (InterruptedException e) {
+        this.wait(timeLeft); // timeLeft is always > 0
+        resource = dequeue();
+        if (null != resource) {
+          LOG.trace("[{}] Waited for {}ms", queueName, timeNow - currentTimeMillis());
+          return resource;
+        }
+        timeLeft = timeExpire - currentTimeMillis();
       }
-      if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_notified__FINEST",
-                new Object[] { Thread.currentThread().getName(), queueName,
-                    String.valueOf(numberElementsInQueue) });
-      }
-      resource = dequeue();
+    } catch (InterruptedException e) {
     }
+
+    if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
+      LOG.logrb(Level.FINEST, this.getClass().getName(), "process",
+              CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_queue_notified__FINEST",
+              new Object[] { Thread.currentThread().getName(), queueName,
+                  String.valueOf(numberElementsInQueue) });
+    }
+
+    resource = dequeue();
     return resource;
   }
 

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
@@ -90,15 +90,15 @@ import org.apache.uima.util.UimaTimer;
 import org.apache.uima.util.impl.ProcessTrace_impl;
 
 /**
- * Responsible for creating and initializing processing threads. This instance manages the lifecycle
- * of the CPE components. It exposes API for plugging in components programmatically instead of
- * declaratively. Running in its own thread, this components creates seperate Processing Pipelines
- * for Analysis Engines and Cas Consumers, launches configured CollectionReader and attaches all of
- * those components to form a pipeline from source to sink. The Collection Reader feeds Processing
- * Threads containing Analysis Engines, and Analysis Engines feed results of analysis to Cas
- * Consumers.
+ * Responsible for creating and initializing processing threads. This instance manages the
+ * life-cycle of the CPE components. It exposes API for plugging in components programmatically
+ * instead of declaratively. Running in its own thread, this components creates separate Processing
+ * Pipelines for Analysis Engines and CAS Consumers, launches configured CollectionReader and
+ * attaches all of those components to form a pipeline from source to sink. The Collection Reader
+ * feeds Processing Threads containing Analysis Engines, and Analysis Engines feed results of
+ * analysis to CAS Consumers.
  */
-public class CPMEngine extends Thread {
+public class CPMEngine implements Runnable {
 
   /** The Constant MAX_WAIT_ON_QUEUE. */
   private static final int MAX_WAIT_ON_QUEUE = 400;
@@ -3266,9 +3266,7 @@ public class CPMEngine extends Thread {
         // Use default Timer
         nonThreadedCasConsumerProcessingUnit.setUimaTimer(new JavaTimer());
       }
-
     }
-
   }
 
   /**
@@ -3490,12 +3488,12 @@ public class CPMEngine extends Thread {
   }
 
   /**
-   * Internal use only, public for crss package access. switches class loaders and locks cas
+   * Internal use only, public for cross package access. switches class loaders and locks cas
    * 
    * @param statCL
    *          status call back listener
    * @param cas
-   *          cas
+   *          CAS
    * @param eps
    *          entity process status
    */
@@ -3555,7 +3553,7 @@ public class CPMEngine extends Thread {
   }
 
   /**
-   * Wait for cpm to resume if paused.
+   * Wait for CPM to resume if paused.
    */
   private void waitForCpmToResumeIfPaused() {
     synchronized (lockForPause) {
@@ -3581,75 +3579,4 @@ public class CPMEngine extends Thread {
       }
     }
   }
-
-  // private static class ThreadGroupDestroyer extends Thread {
-  // private Set<Thread> foreignThreadsBlockingShutdown = new LinkedHashSet<>();
-  //
-  // private final ThreadGroup group;
-  //
-  // private final AtomicInteger count = new AtomicInteger();
-  //
-  // public ThreadGroupDestroyer(ThreadGroup aGroup) {
-  // super(aGroup.getParent(), "threadGroupDestroyer");
-  //
-  // group = aGroup;
-  //
-  // }
-  //
-  // @Override
-  // public void run() {
-  //
-  // while (group.activeCount() > 0) {
-  // try {
-  // Thread.sleep(100);
-  // } catch (InterruptedException e) {
-  // }
-  // Thread[] threads = new Thread[group.activeCount()];
-  // group.enumerate(threads);
-  // showThreads(threads, foreignThreadsBlockingShutdown, count);
-  // }
-  //
-  // if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-  // UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-  // "UIMA_CPM_destroy_thread_group__FINEST",
-  // new Object[] { Thread.currentThread().getName() });
-  // }
-  //
-  // group.destroy();
-  // }
-  //
-  // private void showThreads(Thread[] aThreadList, Set<Thread> foreignThreadsBlockingShutdown,
-  // AtomicInteger count) {
-  // count.incrementAndGet();
-  //
-  // if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-  // for (int i = 0; aThreadList != null && i < aThreadList.length; i++) {
-  // if (aThreadList[i] != null) {
-  // UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_show_thread__FINEST",
-  // new Object[] { Thread.currentThread().getName(), String.valueOf(i),
-  // aThreadList[i].getName() });
-  // }
-  // }
-  // }
-  //
-  // if (count.get() % 5 == 0) {
-  // for (Thread thread : aThreadList) {
-  // Set<Thread> nonUimaThreads = new HashSet<>();
-  // if (!(thread instanceof ProcessingUnit) && !(thread instanceof ArtifactProducer)
-  // && !foreignThreadsBlockingShutdown.contains(thread)) {
-  // nonUimaThreads.add(thread);
-  // }
-  //
-  // if (nonUimaThreads.size() == aThreadList.length) {
-  // UIMAFramework.getLogger(this.getClass()).logrb(Level.WARNING, this.getClass().getName(),
-  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_unknown_thread__WARNING",
-  // new Object[] { thread.getName() });
-  // foreignThreadsBlockingShutdown.add(thread);
-  // }
-  // }
-  // }
-  // }
-  // }
 }

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
@@ -24,16 +24,14 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.adapter.vinci.util.Descriptor;
@@ -111,7 +109,9 @@ public class CPMEngine extends Thread {
   /** The Constant SINGLE_THREADED_MODE. */
   private static final String SINGLE_THREADED_MODE = "single-threaded";
 
-  /** The cas pool. */
+  private final CPMExecutorService executorService;
+
+  /** The CAS pool. */
   public CPECasPool casPool;
 
   /** The lock for pause. */
@@ -215,6 +215,7 @@ public class CPMEngine extends Thread {
   /** The producer. */
   // work Queue
   private ArtifactProducer producer = null;
+  private Future<?> producerResult;
 
   /** The cpe factory. */
   // Factory responsible for instantiating CPE components from CPE descriptor
@@ -223,12 +224,14 @@ public class CPMEngine extends Thread {
   /** The processing units. */
   // An array holding instances of components responsible for analysis
   protected ProcessingUnit[] processingUnits = null;
+  protected Future<?>[] processingUnitResults = null;
 
   // Instantiate a Processing Unit containing CasConsumers. There may be many Analysis Processing
   // Units
   /** The cas consumer PU. */
   // but there is one CasConsumer Processing Unit ( at least for now).
   private ProcessingUnit casConsumerPU = null;
+  private Future<?> casConsumerPUResult;
 
   /** The output queue. */
   // Queue where result of analysis goes to be consumed by Consumers
@@ -309,7 +312,7 @@ public class CPMEngine extends Thread {
    * Initializes Collection Processing Engine. Assigns this thread and all processing threads
    * created by this component to a common Thread Group.
    *
-   * @param aThreadGroup
+   * @param aExecutorService
    *          - contains all CPM related threads
    * @param aCpeFactory
    *          - CPE factory object responsible for parsing cpe descriptor and creating components
@@ -320,9 +323,10 @@ public class CPMEngine extends Thread {
    * @throws Exception
    *           the exception
    */
-  public CPMEngine(CPMThreadGroup aThreadGroup, CPEFactory aCpeFactory, ProcessTrace aProcTr,
-          CheckpointData aCheckpointData) throws Exception {
-    super(aThreadGroup, "CPMEngine Thread");
+  public CPMEngine(CPMExecutorService aExecutorService, CPEFactory aCpeFactory,
+          ProcessTrace aProcTr, CheckpointData aCheckpointData) throws Exception {
+    setName("CPMEngine Thread");
+    executorService = aExecutorService;
     cpeFactory = aCpeFactory;
     // Accumulate trace info in provided ProcessTrace instance
     procTr = aProcTr;
@@ -355,6 +359,10 @@ public class CPMEngine extends Thread {
         }
       }
     }
+  }
+
+  CPMExecutorService getExecutorService() {
+    return executorService;
   }
 
   /**
@@ -647,7 +655,8 @@ public class CPMEngine extends Thread {
               "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_terminate_pipelines__INFO",
               new Object[] { Thread.currentThread().getName(), String.valueOf(killed) });
     }
-    new Thread() {
+
+    executorService.submit(new Thread() {
       @Override
       public void run() {
         Object[] eofToken = new Object[1];
@@ -739,10 +748,8 @@ public class CPMEngine extends Thread {
                   "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_exception__FINER",
                   new Object[] { Thread.currentThread().getName(), e.getMessage() });
         }
-
       }
-    }.start();
-
+    });
   }
 
   /**
@@ -1686,7 +1693,7 @@ public class CPMEngine extends Thread {
   private void startDebugControlThread() {
     String dbgCtrlFile = System.getProperty("DEBUG_CONTROL");
     dbgCtrlThread = new DebugControlThread(this, dbgCtrlFile, 1000);
-    dbgCtrlThread.start();
+    executorService.submit(dbgCtrlThread);
   }
 
   /**
@@ -1840,13 +1847,8 @@ public class CPMEngine extends Thread {
                 new Object[] { Thread.currentThread().getName(), t.getMessage() });
         return;
       } finally {
-        ((CPMThreadGroup) getThreadGroup()).cleanup();
-        // Fix for memory leak. CPMThreadGroup must be
-        // destroyed, but not until AFTER all threads that it
-        // owns, including this one, have ended. - Adam
-        final ThreadGroup group = getThreadGroup();
-        Thread threadGroupDestroyer = new ThreadGroupDestroyer(group);
-        threadGroupDestroyer.start();
+        executorService.cleanup();
+        executorService.shutdown();
       }
     }
 
@@ -2015,7 +2017,7 @@ public class CPMEngine extends Thread {
         // name the thread
         casConsumerPU.setName("[CasConsumer Pipeline Thread]::");
         // start the CasConsumer Thread
-        casConsumerPU.start();
+        casConsumerPUResult = executorService.submit(casConsumerPU);
         consumerThreadStarted = true;
       }
       if (UIMAFramework.getLogger().isLoggable(Level.CONFIG)) {
@@ -2068,6 +2070,7 @@ public class CPMEngine extends Thread {
 
       // Setup Processing Pipelines
       processingUnits = new ProcessingUnit[concurrentThreadCount];
+      processingUnitResults = new Future<?>[concurrentThreadCount];
       synchronized (this) {
         activeProcessingUnits = concurrentThreadCount; // keeps track of how many threads are still
         // active. -Adam
@@ -2145,7 +2148,7 @@ public class CPMEngine extends Thread {
         processingUnits[i].setName("[Procesing Pipeline#" + (i + 1) + " Thread]::");
 
         // Start the Processing Pipeline
-        processingUnits[i].start();
+        processingUnitResults[i] = executorService.submit(processingUnits[i]);
         processingThreadsState[i] = 1; // Started
       }
 
@@ -2153,7 +2156,7 @@ public class CPMEngine extends Thread {
       // Start the ArtifactProducer thread and the Collection Reader embedded therein. The
       // Collection Reader begins
       // processing and deposits CASes onto a work queue.
-      producer.start();
+      producerResult = executorService.submit(producer);
       readerThreadStarted = true;
 
       // Indicate that ALL threads making up the CPE have been started
@@ -2180,7 +2183,7 @@ public class CPMEngine extends Thread {
       // simply terminates the thread. Once it terminates lets just make sure that
       // all threads finish and the work queue is completely depleted and all entities
       // are processed
-      producer.join();
+      producerResult.get();
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
         UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
                 "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cr_thread_completed__FINEST",
@@ -2195,7 +2198,7 @@ public class CPMEngine extends Thread {
                   new Object[] { Thread.currentThread().getName(), processingUnits[i].getName(),
                       String.valueOf(i) });
         }
-        processingUnits[i].join();
+        processingUnitResults[i].get();
         if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
           UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
                   "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_join_pu_complete__FINEST",
@@ -2250,7 +2253,7 @@ public class CPMEngine extends Thread {
 
         }
 
-        casConsumerPU.join();
+        casConsumerPUResult.get();
         if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
           UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
                   "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_join_cc_completed__FINEST",
@@ -2361,9 +2364,9 @@ public class CPMEngine extends Thread {
         if (producer != null && !producer.isRunning()) {
           try {
             if (!readerThreadStarted) {
-              producer.start();
+              executorService.submit(producer);
             }
-            producer.join();
+            producerResult.get();
           } catch (Exception ex1) {
             UIMAFramework.getLogger(this.getClass()).logrb(Level.SEVERE, this.getClass().getName(),
                     "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cr_exception__SEVERE",
@@ -2377,9 +2380,9 @@ public class CPMEngine extends Thread {
         if (casConsumerPU != null && !casConsumerPU.isRunning()) {
           try {
             if (!consumerThreadStarted) {
-              casConsumerPU.start();
+              executorService.submit(casConsumerPU);
             }
-            casConsumerPU.join();
+            casConsumerPUResult.get();
           } catch (Exception ex1) {
             UIMAFramework.getLogger(this.getClass()).logrb(Level.SEVERE, this.getClass().getName(),
                     "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cc_exception__SEVERE",
@@ -2412,10 +2415,10 @@ public class CPMEngine extends Thread {
               // In such a case 'processingThreadsState[i] = -1'
 
               if (processingThreadsState[i] == -1 && !processingUnits[i].isRunning()) {
-                processingUnits[i].start();
+                executorService.submit(processingUnits[i]);
               }
               try {
-                processingUnits[i].join();
+                processingUnitResults[i].get();
                 if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
                   UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST,
                           this.getClass().getName(), "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
@@ -2485,9 +2488,11 @@ public class CPMEngine extends Thread {
           notifyListenersWithException(e);
         }
         try {
-          casConsumerPU.join();
+          casConsumerPUResult.get();
         } catch (InterruptedException e) {
 
+        } catch (ExecutionException e) {
+          e.printStackTrace();
         }
         if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
           UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
@@ -2496,12 +2501,7 @@ public class CPMEngine extends Thread {
         }
       }
 
-      // Fix for memory leak. CPMThreadGroup must be
-      // destroyed, but not until AFTER all threads that it
-      // owns, including this one, have ended. - Adam
-      final ThreadGroup group = getThreadGroup();
-      Thread threadGroupDestroyer = new ThreadGroupDestroyer(group);
-      threadGroupDestroyer.start();
+      executorService.shutdown();
     }
   }
 
@@ -2593,6 +2593,7 @@ public class CPMEngine extends Thread {
         producer.cleanup();
       }
       producer = null;
+      producerResult = null;
 
       if (consumerDeployList != null) {
         consumerDeployList.clear();
@@ -2625,6 +2626,7 @@ public class CPMEngine extends Thread {
       consumers = null;
 
       processingUnits = null;
+      processingUnitResults = null;
       casprocessorList = null;
       // this.enProcSt = null;
       stats = null;
@@ -3580,74 +3582,74 @@ public class CPMEngine extends Thread {
     }
   }
 
-  private static class ThreadGroupDestroyer extends Thread {
-    private Set<Thread> foreignThreadsBlockingShutdown = new LinkedHashSet<>();
-
-    private final ThreadGroup group;
-
-    private final AtomicInteger count = new AtomicInteger();
-
-    public ThreadGroupDestroyer(ThreadGroup aGroup) {
-      super(aGroup.getParent(), "threadGroupDestroyer");
-
-      group = aGroup;
-
-    }
-
-    @Override
-    public void run() {
-
-      while (group.activeCount() > 0) {
-        try {
-          Thread.sleep(100);
-        } catch (InterruptedException e) {
-        }
-        Thread[] threads = new Thread[group.activeCount()];
-        group.enumerate(threads);
-        showThreads(threads, foreignThreadsBlockingShutdown, count);
-      }
-
-      if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                "UIMA_CPM_destroy_thread_group__FINEST",
-                new Object[] { Thread.currentThread().getName() });
-      }
-
-      group.destroy();
-    }
-
-    private void showThreads(Thread[] aThreadList, Set<Thread> foreignThreadsBlockingShutdown,
-            AtomicInteger count) {
-      count.incrementAndGet();
-
-      if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        for (int i = 0; aThreadList != null && i < aThreadList.length; i++) {
-          if (aThreadList[i] != null) {
-            UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
-                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_show_thread__FINEST",
-                    new Object[] { Thread.currentThread().getName(), String.valueOf(i),
-                        aThreadList[i].getName() });
-          }
-        }
-      }
-
-      if (count.get() % 5 == 0) {
-        for (Thread thread : aThreadList) {
-          Set<Thread> nonUimaThreads = new HashSet<>();
-          if (!(thread instanceof ProcessingUnit) && !(thread instanceof ArtifactProducer)
-                  && !foreignThreadsBlockingShutdown.contains(thread)) {
-            nonUimaThreads.add(thread);
-          }
-
-          if (nonUimaThreads.size() == aThreadList.length) {
-            UIMAFramework.getLogger(this.getClass()).logrb(Level.WARNING, this.getClass().getName(),
-                    "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_unknown_thread__WARNING",
-                    new Object[] { thread.getName() });
-            foreignThreadsBlockingShutdown.add(thread);
-          }
-        }
-      }
-    }
-  }
+  // private static class ThreadGroupDestroyer extends Thread {
+  // private Set<Thread> foreignThreadsBlockingShutdown = new LinkedHashSet<>();
+  //
+  // private final ThreadGroup group;
+  //
+  // private final AtomicInteger count = new AtomicInteger();
+  //
+  // public ThreadGroupDestroyer(ThreadGroup aGroup) {
+  // super(aGroup.getParent(), "threadGroupDestroyer");
+  //
+  // group = aGroup;
+  //
+  // }
+  //
+  // @Override
+  // public void run() {
+  //
+  // while (group.activeCount() > 0) {
+  // try {
+  // Thread.sleep(100);
+  // } catch (InterruptedException e) {
+  // }
+  // Thread[] threads = new Thread[group.activeCount()];
+  // group.enumerate(threads);
+  // showThreads(threads, foreignThreadsBlockingShutdown, count);
+  // }
+  //
+  // if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
+  // UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
+  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+  // "UIMA_CPM_destroy_thread_group__FINEST",
+  // new Object[] { Thread.currentThread().getName() });
+  // }
+  //
+  // group.destroy();
+  // }
+  //
+  // private void showThreads(Thread[] aThreadList, Set<Thread> foreignThreadsBlockingShutdown,
+  // AtomicInteger count) {
+  // count.incrementAndGet();
+  //
+  // if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
+  // for (int i = 0; aThreadList != null && i < aThreadList.length; i++) {
+  // if (aThreadList[i] != null) {
+  // UIMAFramework.getLogger(this.getClass()).logrb(Level.FINEST, this.getClass().getName(),
+  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_show_thread__FINEST",
+  // new Object[] { Thread.currentThread().getName(), String.valueOf(i),
+  // aThreadList[i].getName() });
+  // }
+  // }
+  // }
+  //
+  // if (count.get() % 5 == 0) {
+  // for (Thread thread : aThreadList) {
+  // Set<Thread> nonUimaThreads = new HashSet<>();
+  // if (!(thread instanceof ProcessingUnit) && !(thread instanceof ArtifactProducer)
+  // && !foreignThreadsBlockingShutdown.contains(thread)) {
+  // nonUimaThreads.add(thread);
+  // }
+  //
+  // if (nonUimaThreads.size() == aThreadList.length) {
+  // UIMAFramework.getLogger(this.getClass()).logrb(Level.WARNING, this.getClass().getName(),
+  // "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_unknown_thread__WARNING",
+  // new Object[] { thread.getName() });
+  // foreignThreadsBlockingShutdown.add(thread);
+  // }
+  // }
+  // }
+  // }
+  // }
 }

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
@@ -1054,7 +1054,7 @@ public class CPMEngine extends Thread {
    */
   private void addParallizableCasProcessor(CasProcessor aProcessor, String aCpName)
           throws Exception {
-    UIMAFramework.getLogger(this.getClass()).log(Level.CONFIG, " Adding New Annotator:" + aCpName);
+    UIMAFramework.getLogger(this.getClass()).log(Level.CONFIG, "Adding new annotator:" + aCpName);
     if (analysisEngines.containsKey(aCpName)) {
       if (UIMAFramework.getLogger().isLoggable(Level.CONFIG)) {
         UIMAFramework.getLogger(this.getClass()).logrb(Level.CONFIG, this.getClass().getName(),

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMEngine.java
@@ -325,7 +325,6 @@ public class CPMEngine extends Thread {
    */
   public CPMEngine(CPMExecutorService aExecutorService, CPEFactory aCpeFactory,
           ProcessTrace aProcTr, CheckpointData aCheckpointData) throws Exception {
-    setName("CPMEngine Thread");
     executorService = aExecutorService;
     cpeFactory = aCpeFactory;
     // Accumulate trace info in provided ProcessTrace instance
@@ -1825,6 +1824,8 @@ public class CPMEngine extends Thread {
    */
   @Override
   public void run() {
+    Thread.currentThread().setName("CPMEngine Thread");
+
     boolean consumerCompleted = false;
     boolean isStarted = false; // Indicates if all threads have been started
 
@@ -1985,7 +1986,6 @@ public class CPMEngine extends Thread {
       // input queue and there is an exception BEFORE Processing Units starts. This may lead
       // to a hang, because the CR is waiting on the CAS Pool and no-one consumes the Input Queue.
       // Name the thread
-      producer.setName("[CollectionReader Thread]::");
 
       // Create Cas Consumer Thread
       if (consumerList != null && consumerList.size() > 0) {

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMExecutorService.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/CPMExecutorService.java
@@ -19,6 +19,7 @@
 
 package org.apache.uima.collection.impl.cpm.engine;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.uima.UIMAFramework.getLogger;
 import static org.apache.uima.collection.impl.cpm.utils.CPMUtils.CPM_LOG_RESOURCE_BUNDLE;
 import static org.apache.uima.util.Level.FINER;
@@ -41,8 +42,8 @@ import org.apache.uima.util.ProcessTrace;
 
 /**
  * This component catches uncaught errors in the CPM. All critical threads in the CPM are part of
- * this ThreadGroup. If OutOfMemory Error is thrown this component is notified by the JVM and its
- * job is to notify registered listeners.
+ * this executor service. If OutOfMemory Error is thrown this component is notified by the JVM and
+ * its job is to notify registered listeners.
  */
 public class CPMExecutorService extends ThreadPoolExecutor {
 
@@ -51,7 +52,7 @@ public class CPMExecutorService extends ThreadPoolExecutor {
   private ProcessTrace procTr = null;
 
   public CPMExecutorService() {
-    super(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+    super(0, Integer.MAX_VALUE, 60L, SECONDS, new SynchronousQueue<Runnable>());
   }
 
   /**

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/DebugControlThread.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/DebugControlThread.java
@@ -29,12 +29,11 @@ import org.apache.uima.collection.impl.cpm.utils.CpmLocalizedMessage;
 import org.apache.uima.util.FileUtils;
 import org.apache.uima.util.Level;
 
-
 /**
  * The Class DebugControlThread.
  */
 public class DebugControlThread implements Runnable {
-  
+
   /** The Constant NOTFOUND. */
   private final static String NOTFOUND = "NOT-FOUND";
 
@@ -61,9 +60,12 @@ public class DebugControlThread implements Runnable {
   /**
    * Instantiates a new debug control thread.
    *
-   * @param aCpm the a cpm
-   * @param aFilename the a filename
-   * @param aCheckpointFrequency the a checkpoint frequency
+   * @param aCpm
+   *          the a cpm
+   * @param aFilename
+   *          the a filename
+   * @param aCheckpointFrequency
+   *          the a checkpoint frequency
    */
   public DebugControlThread(CPMEngine aCpm, String aFilename, int aCheckpointFrequency) {
     cpm = aCpm;
@@ -74,7 +76,8 @@ public class DebugControlThread implements Runnable {
   /**
    * Start.
    *
-   * @throws RuntimeException the runtime exception
+   * @throws RuntimeException
+   *           the runtime exception
    */
   public void start() throws RuntimeException {
     if (fileName == null) {
@@ -84,10 +87,10 @@ public class DebugControlThread implements Runnable {
                 "UIMA_CPM_checkpoint_target_not_defined__FINEST",
                 new Object[] { Thread.currentThread().getName() });
       }
-      throw new RuntimeException(CpmLocalizedMessage.getLocalizedMessage(
-              CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-              "UIMA_CPM_EXP_target_checkpoint_not_defined__WARNING", new Object[] { Thread
-                      .currentThread().getName() }));
+      throw new RuntimeException(
+              CpmLocalizedMessage.getLocalizedMessage(CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                      "UIMA_CPM_EXP_target_checkpoint_not_defined__WARNING",
+                      new Object[] { Thread.currentThread().getName() }));
     }
     if (cpm == null) {
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
@@ -100,7 +103,7 @@ public class DebugControlThread implements Runnable {
               CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_EXP_invalid_cpm__WARNING",
               new Object[] { Thread.currentThread().getName() }));
     } else {
-      new Thread(this).start();
+      cpm.getExecutorService().submit(this);
     }
   }
 
@@ -113,7 +116,9 @@ public class DebugControlThread implements Runnable {
     doCheckpoint();
   }
 
-  /* (non-Javadoc)
+  /*
+   * (non-Javadoc)
+   * 
    * @see java.lang.Runnable#run()
    */
   @Override
@@ -147,7 +152,8 @@ public class DebugControlThread implements Runnable {
   /**
    * Interpret and execute command.
    *
-   * @param aCommand the a command
+   * @param aCommand
+   *          the a command
    */
   private void interpretAndExecuteCommand(String aCommand) {
     if (aCommand == null) {

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ProcessingUnit.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ProcessingUnit.java
@@ -61,7 +61,6 @@ import org.apache.uima.util.ProcessTrace;
 import org.apache.uima.util.UimaTimer;
 import org.apache.uima.util.impl.ProcessTrace_impl;
 
-
 /**
  * This component executes the processing pipeline. Running in a seperate thread it continuously
  * reads bundles of Cas from the Work Queue filled by {@link ArtifactProducer} and sends it through
@@ -72,7 +71,7 @@ import org.apache.uima.util.impl.ProcessTrace_impl;
  * 
  */
 public class ProcessingUnit extends Thread {
-  
+
   /** The thread state. */
   public int threadState = 0;
 
@@ -169,14 +168,15 @@ public class ProcessingUnit extends Thread {
   /**
    * Initialize the PU.
    *
-   * @param acpm -
-   *          component managing life cycle of the CPE
-   * @param aInputQueue -
-   *          queue to read from
-   * @param aOutputQueue -
-   *          queue to write to
+   * @param acpm
+   *          - component managing life cycle of the CPE
+   * @param aInputQueue
+   *          - queue to read from
+   * @param aOutputQueue
+   *          - queue to write to
    */
-  public ProcessingUnit(CPMEngine acpm, BoundedWorkQueue aInputQueue, BoundedWorkQueue aOutputQueue) {
+  public ProcessingUnit(CPMEngine acpm, BoundedWorkQueue aInputQueue,
+          BoundedWorkQueue aOutputQueue) {
     cpm = acpm;
     try {
       cpeConfiguration = cpm.getCpeConfig();
@@ -194,7 +194,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Instantiates a new processing unit.
    *
-   * @param acpm the acpm
+   * @param acpm
+   *          the acpm
    */
   public ProcessingUnit(CPMEngine acpm) {
     cpm = acpm;
@@ -235,8 +236,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Alternative method of providing a queue from which this PU will read bundle of Cas.
    *
-   * @param aInputQueue -
-   *          read queue
+   * @param aInputQueue
+   *          - read queue
    */
   public void setInputQueue(BoundedWorkQueue aInputQueue) {
     workQueue = aInputQueue;
@@ -245,8 +246,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Alternative method of providing a queue where this PU will deposit results of analysis.
    *
-   * @param aOutputQueue -
-   *          queue to write to
+   * @param aOutputQueue
+   *          - queue to write to
    */
   public void setOutputQueue(BoundedWorkQueue aOutputQueue) {
     outputQueue = aOutputQueue;
@@ -256,8 +257,8 @@ public class ProcessingUnit extends Thread {
    * Alternative method of providing the reference to the component managing the lifecycle of the
    * CPE.
    *
-   * @param acpm -
-   *          reference to the contrlling engine
+   * @param acpm
+   *          - reference to the contrlling engine
    */
   public void setCPMEngine(CPMEngine acpm) {
     cpm = acpm;
@@ -285,8 +286,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Set a flag indicating if notifications should be made via configured Listeners.
    *
-   * @param aDoNotify -
-   *          true if notification is required, false otherwise
+   * @param aDoNotify
+   *          - true if notification is required, false otherwise
    */
   public void setNotifyListeners(boolean aDoNotify) {
     notifyListeners = aDoNotify;
@@ -295,8 +296,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Plugs in Listener object used for notifications.
    * 
-   * @param aListener -
-   *          {@link org.apache.uima.collection.base_cpm.BaseStatusCallbackListener} instance
+   * @param aListener
+   *          - {@link org.apache.uima.collection.base_cpm.BaseStatusCallbackListener} instance
    */
   public void addStatusCallbackListener(BaseStatusCallbackListener aListener) {
     statusCbL.add(aListener);
@@ -315,8 +316,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Removes given listener from the list of listeners.
    *
-   * @param aListener -
-   *          object to remove from the list
+   * @param aListener
+   *          - object to remove from the list
    */
   public void removeStatusCallbackListener(BaseStatusCallbackListener aListener) {
     statusCbL.remove(aListener);
@@ -325,8 +326,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Plugs in ProcessTrace object used to collect statistics.
    *
-   * @param aProcessingUnitProcessTrace -
-   *          object to compile stats
+   * @param aProcessingUnitProcessTrace
+   *          - object to compile stats
    */
   public void setProcessingUnitProcessTrace(ProcessTrace aProcessingUnitProcessTrace) {
     processingUnitProcessTrace = aProcessingUnitProcessTrace;
@@ -336,8 +337,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Plugs in custom timer used by the PU for getting time.
    *
-   * @param aTimer -
-   *          custom timer to use
+   * @param aTimer
+   *          - custom timer to use
    */
   public void setUimaTimer(UimaTimer aTimer) {
     timer = aTimer;
@@ -361,8 +362,8 @@ public class ProcessingUnit extends Thread {
    * Disable a CASProcessor in the processing pipeline. Locate it by provided index. The disabled
    * Cas Processor remains in the Processing Pipeline, however it is not used furing processing.
    * 
-   * @param aCasProcessorIndex -
-   *          location in the pipeline of the Cas Processor to delete
+   * @param aCasProcessorIndex
+   *          - location in the pipeline of the Cas Processor to delete
    */
   public void disableCasProcessor(int aCasProcessorIndex) {
     if (aCasProcessorIndex < 0 || aCasProcessorIndex > processContainers.size()) {
@@ -380,8 +381,8 @@ public class ProcessingUnit extends Thread {
    * 
    * Alternative method to disable Cas Processor. Uses a name to locate it.
    * 
-   * @param aCasProcessorName -
-   *          a name of the Cas Processor to disable
+   * @param aCasProcessorName
+   *          - a name of the Cas Processor to disable
    */
   public void disableCasProcessor(String aCasProcessorName) {
     for (int i = 0; i < processContainers.size(); i++) {
@@ -398,8 +399,8 @@ public class ProcessingUnit extends Thread {
    * Enables Cas Processor with a given name. Enabled Cas Processor will immediately begin to
    * receive bundles of Cas.
    * 
-   * @param aCasProcessorName -
-   *          name of the Cas Processor to enable
+   * @param aCasProcessorName
+   *          - name of the Cas Processor to enable
    */
   public void enableCasProcessor(String aCasProcessorName) {
     for (int i = 0; i < processContainers.size(); i++) {
@@ -437,7 +438,8 @@ public class ProcessingUnit extends Thread {
    * be generated by ArtifactProducer if end of collection is reached, or the CPM itself can place
    * it in the Work Queue to force all processing threads to stop.
    * 
-   * @throws Exception -
+   * @throws Exception
+   *           -
    */
   private void handleEOFToken() throws Exception {
     maybeLogFinest("UIMA_CPM_got_eof_token__FINEST");
@@ -449,9 +451,9 @@ public class ProcessingUnit extends Thread {
       if (cpm.getThreadCount() > 1) {
         // Put EOF Token back to queue to ensure that all PUs get it
         workQueue.enqueue(artifact);
-//        synchronized (workQueue) { redundant - the above enqueue call does this
-//          workQueue.notifyAll();
-//        }
+        // synchronized (workQueue) { redundant - the above enqueue call does this
+        // workQueue.notifyAll();
+        // }
       }
       if (outputQueue != null) {
         maybeLogFinest("UIMA_CPM_placed_eof_in_queue__FINEST", outputQueue.getName());
@@ -478,17 +480,17 @@ public class ProcessingUnit extends Thread {
    * are invalidated. Invalidated in the sense that they are marked as timed out. Each CAS will be
    * released back to the CAS Pool.
    * 
-   * @param artifact -
-   *          an array of CAS instances
+   * @param artifact
+   *          - an array of CAS instances
    */
   private void releaseTimedOutCases(Object[] artifact) {
     for (int j = 0; j < artifact.length; j++) {
       if (artifact[j] != null) {
         // Release CASes that timed out back to the pool
         casPool.releaseCas((CAS) artifact[j]);
-//        synchronized (casPool) { // redundant - the above releaseCas call does this
-//          casPool.notifyAll();
-//        }
+        // synchronized (casPool) { // redundant - the above releaseCas call does this
+        // casPool.notifyAll();
+        // }
         artifact[j] = null;
       }
     }
@@ -521,6 +523,8 @@ public class ProcessingUnit extends Thread {
    */
   @Override
   public void run() {
+    Thread.currentThread().setName(getName());
+
     if (!cpm.isRunning()) {
 
       UIMAFramework.getLogger(this.getClass()).logrb(Level.WARNING, this.getClass().getName(),
@@ -577,9 +581,9 @@ public class ProcessingUnit extends Thread {
               if (meta != null) {
                 EntityProcessStatusImpl enProcSt = new EntityProcessStatusImpl(
                         processingUnitProcessTrace);
-                enProcSt.addEventStatus("Process", "Failed", new SkipCasException(
-                        "Dropping CAS due chunk Timeout. Doc Id::" + meta.getDocId() + " Sequence:"
-                                + meta.getSequence()));
+                enProcSt.addEventStatus("Process", "Failed",
+                        new SkipCasException("Dropping CAS due chunk Timeout. Doc Id::"
+                                + meta.getDocId() + " Sequence:" + meta.getSequence()));
                 doNotifyListeners(artifact[i], true, enProcSt);
               } else {
                 EntityProcessStatusImpl enProcSt = new EntityProcessStatusImpl(
@@ -612,7 +616,7 @@ public class ProcessingUnit extends Thread {
           handleEOFToken();
           break; // Terminate Loop
         }
-        
+
         maybeLogFinest("UIMA_CPM_call_processNext__FINEST");
         /* *********** EXECUTE PIPELINE ************ */
         processNext(artifact, pT);
@@ -669,9 +673,9 @@ public class ProcessingUnit extends Thread {
           // casCache[index].reset();
           maybeLogFinest("UIMA_CPM_release_cas_from_cache__FINEST");
           casPool.releaseCas(casCache[index]);
-//          synchronized (casPool) { // redundant - the above releaseCas call does this
-//            casPool.notifyAll();
-//          }
+          // synchronized (casPool) { // redundant - the above releaseCas call does this
+          // casPool.notifyAll();
+          // }
 
           maybeLogFinest("UIMA_CPM_release_cas_from_cache_done__FINEST");
         }
@@ -723,21 +727,28 @@ public class ProcessingUnit extends Thread {
    * fly. Two types of Cas Processors are currently supported:
    * 
    * <ul>
-   * <li> CasDataProcessor</li>
-   * <li> CasObjectProcessor</li>
+   * <li>CasDataProcessor</li>
+   * <li>CasObjectProcessor</li>
    * </ul>
    * 
    * The first operates on instances of CasData the latter operates on instances of CAS. The results
    * produced by Cas Processors are added to the output queue.
    *
-   * @param aCasObjectList - bundle of Cas to analyze
-   * @param pTrTemp - object used to aggregate stats
+   * @param aCasObjectList
+   *          - bundle of Cas to analyze
+   * @param pTrTemp
+   *          - object used to aggregate stats
    * @return true, if successful
-   * @throws ResourceProcessException the resource process exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   * @throws CollectionException the collection exception
-   * @throws AbortCPMException the abort CPM exception
-   * @throws KillPipelineException the kill pipeline exception
+   * @throws ResourceProcessException
+   *           the resource process exception
+   * @throws IOException
+   *           Signals that an I/O exception has occurred.
+   * @throws CollectionException
+   *           the collection exception
+   * @throws AbortCPMException
+   *           the abort CPM exception
+   * @throws KillPipelineException
+   *           the kill pipeline exception
    */
   protected boolean processNext(Object[] aCasObjectList, ProcessTrace pTrTemp)
           throws ResourceProcessException, IOException, CollectionException, AbortCPMException,
@@ -768,7 +779,7 @@ public class ProcessingUnit extends Thread {
     // *******************************************
     // Send Cas Object through the processing pipeline.
     for (int i = 0; processContainers != null && i < processContainers.size(); i++) {
-      
+
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
         logFinest("UIMA_CPM_retrieve_container__FINEST", String.valueOf(i));
       }
@@ -814,8 +825,8 @@ public class ProcessingUnit extends Thread {
           maybeLogSevere("UIMA_CPM_checkout_null_cp_from_container__SEVERE", container.getName());
           throw new ResourceProcessException(CpmLocalizedMessage.getLocalizedMessage(
                   CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                  "UIMA_CPM_EXP_invalid_component_reference__WARNING", new Object[] {
-                      Thread.currentThread().getName(), "CasProcessor", "NULL" }), null);
+                  "UIMA_CPM_EXP_invalid_component_reference__WARNING",
+                  new Object[] { Thread.currentThread().getName(), "CasProcessor", "NULL" }), null);
         }
         // Check to see if the CasProcessor is available for processing
         // Container may have been disabled by another thread, so first check
@@ -899,8 +910,8 @@ public class ProcessingUnit extends Thread {
               maybeLogFinest("UIMA_CPM_initialize_cas__FINEST", container);
               if (aCasObjectList[casIndex] == null) {
                 if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
-                  logSevere("UIMA_CPM_casobjectlist_is_null__SEVERE", 
-                      container.getName(), String.valueOf(casIndex));
+                  logSevere("UIMA_CPM_casobjectlist_is_null__SEVERE", container.getName(),
+                          String.valueOf(casIndex));
                 }
                 break;
               }
@@ -912,7 +923,7 @@ public class ProcessingUnit extends Thread {
 
                   while (casList[casIndex] == null) {
                     maybeLogFinest("UIMA_CPM_get_cas_from_pool__FINEST", container);
-                     // Retrieve a Cas from Cas Pool. Wait max 10 millis for an instance
+                    // Retrieve a Cas from Cas Pool. Wait max 10 millis for an instance
                     casList[casIndex] = casPool.getCas(0);
                     maybeLogFinest("UIMA_CPM_got_cas_from_pool__FINEST", container);
                   }
@@ -934,8 +945,8 @@ public class ProcessingUnit extends Thread {
               } else {
                 casList[casIndex] = (CAS) aCasObjectList[casIndex];
               }
-              //	Set the type from CasData to CasObject. When an error occurs in the proces()
-              //	we need to know what type of object we deal with. 
+              // Set the type from CasData to CasObject. When an error occurs in the proces()
+              // we need to know what type of object we deal with.
               isCasObject = true;
               aCasObjectList = casList;
 
@@ -968,8 +979,8 @@ public class ProcessingUnit extends Thread {
             notifyListeners(aCasObjectList, isCasObject, aEntityProcStatus);
             if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
               logFinest("UIMA_CPM_done_notify_listeners__FINEST");
-              logFinest("UIMA_CPM_releasing_cases__FINEST",
-                container.getName(), String.valueOf(releaseCAS), "true");
+              logFinest("UIMA_CPM_releasing_cases__FINEST", container.getName(),
+                      String.valueOf(releaseCAS), "true");
             }
             if (casCache != null) {
               clearCasCache();
@@ -999,8 +1010,8 @@ public class ProcessingUnit extends Thread {
 
             maybeLogSevereException(e);
 
-            logFinest("UIMA_CPM_pipeline_exception__FINEST", 
-                container.getName(), String.valueOf(container.isPaused()));
+            logFinest("UIMA_CPM_pipeline_exception__FINEST", container.getName(),
+                    String.valueOf(container.isPaused()));
           }
 
           EntityProcessStatusImpl enProcSt = new EntityProcessStatusImpl(pTrTemp);
@@ -1024,8 +1035,8 @@ public class ProcessingUnit extends Thread {
               cpm.invalidateCASes((CAS[]) aCasObjectList);
             }
             retry = false; // Dont retry. The CAS has been released
-            maybeLogWarning("UIMA_CPM_drop_cas__WARNING", 
-                container.getName(), processor.getClass().getName());
+            maybeLogWarning("UIMA_CPM_drop_cas__WARNING", container.getName(),
+                    processor.getClass().getName());
           } else {
             retry = true; // default on Exception
           }
@@ -1073,8 +1084,8 @@ public class ProcessingUnit extends Thread {
             threadId = Thread.currentThread().getName();
           }
 
-          if (processor instanceof CasDataProcessor
-                  || (processor instanceof CasObjectProcessor && !(processor instanceof AnalysisEngine))) {
+          if (processor instanceof CasDataProcessor || (processor instanceof CasObjectProcessor
+                  && !(processor instanceof AnalysisEngine))) {
             try {
               pTrTemp.endEvent(container.getName(), "Process", "failed");
             } catch (Exception exc) {
@@ -1106,8 +1117,8 @@ public class ProcessingUnit extends Thread {
               handleKillPipeline(container);
               processor = null;
             } catch (Exception innerE) {
-              maybeLogWarning("UIMA_CPM_exception_on_pipeline_kill__WARNING",
-                  container.getName(), innerE.getMessage());
+              maybeLogWarning("UIMA_CPM_exception_on_pipeline_kill__WARNING", container.getName(),
+                      innerE.getMessage());
             }
             // finally
             // {
@@ -1119,8 +1130,8 @@ public class ProcessingUnit extends Thread {
             try {
               handleAbortCPM(container, processor);
             } catch (Exception innerE) {
-              maybeLogWarning("UIMA_CPM_exception_on_cpm_kill__WARNING", 
-                  container.getName(), innerE.getMessage());
+              maybeLogWarning("UIMA_CPM_exception_on_cpm_kill__WARNING", container.getName(),
+                      innerE.getMessage());
             }
             // finally
             // {
@@ -1178,8 +1189,8 @@ public class ProcessingUnit extends Thread {
                   processor = null;
                 } catch (Exception excep) {
                   // Just log the exception. We are killing the pipeline
-                  maybeLogWarning("UIMA_CPM_exception_on_pipeline_kill__WARNING", 
-                      container.getName(), excep.getMessage());
+                  maybeLogWarning("UIMA_CPM_exception_on_pipeline_kill__WARNING",
+                          container.getName(), excep.getMessage());
                 }
               }
               pTrTemp.endEvent(container.getName(), "Process", "failure");
@@ -1209,7 +1220,7 @@ public class ProcessingUnit extends Thread {
             }
           } catch (Exception ex) {
             if (UIMAFramework.getLogger().isLoggable(Level.FINER)) {
-              logCPM(Level.FINER, "UIMA_CPM_exception__FINER", new Object[] {ex.getMessage()});
+              logCPM(Level.FINER, "UIMA_CPM_exception__FINER", new Object[] { ex.getMessage() });
               ex.printStackTrace();
             }
 
@@ -1254,7 +1265,7 @@ public class ProcessingUnit extends Thread {
       throw new ResourceProcessException(rpe);
     }
     maybeLogFinest("UIMA_CPM_pipeline_completed__FINEST");
- 
+
     return true;
   }
 
@@ -1262,16 +1273,18 @@ public class ProcessingUnit extends Thread {
    * Notifies application listeners of completed analysis and stores results of analysis (CAS) in
    * the Output Queue that this thread shares with a Cas Consumer thread.
    *
-   * @param aCasObjectList -
-   *          List of Artifacts just analyzed
-   * @param isCasObject -
-   *          determines the types of CAS just analyzed ( CasData vs CasObject)
-   * @param casObjects the cas objects
-   * @param aProcessTr -
-   *          ProcessTrace object holding events and stats
-   * @param doneAlready -
-   *          flag to indicate if the last Cas Processor was released back to its container
-   * @throws Exception -
+   * @param aCasObjectList
+   *          - List of Artifacts just analyzed
+   * @param isCasObject
+   *          - determines the types of CAS just analyzed ( CasData vs CasObject)
+   * @param casObjects
+   *          the cas objects
+   * @param aProcessTr
+   *          - ProcessTrace object holding events and stats
+   * @param doneAlready
+   *          - flag to indicate if the last Cas Processor was released back to its container
+   * @throws Exception
+   *           -
    */
   private void postAnalysis(Object[] aCasObjectList, boolean isCasObject, Object[] casObjects,
           ProcessTrace aProcessTr, boolean doneAlready) throws Exception {
@@ -1288,8 +1301,8 @@ public class ProcessingUnit extends Thread {
         maybeLogFinest("UIMA_CPM_done_notify_listeners__FINEST");
       }
       // enqueue CASes. If the CPM is in shutdown mode due to hard kill dont allow enqueue of CASes
-      if (outputQueue != null
-              && (cpm.isRunning() == true || (cpm.isRunning() == false && cpm.isHardKilled() == false))) {
+      if (outputQueue != null && (cpm.isRunning() == true
+              || (cpm.isRunning() == false && cpm.isHardKilled() == false))) {
         maybeLogFinestWorkQueue("UIMA_CPM_add_cas_to_queue__FINEST", outputQueue);
         WorkUnit workUnit = new WorkUnit(aCasObjectList);
         if (casCache != null && casCache[0] != null) {
@@ -1301,9 +1314,9 @@ public class ProcessingUnit extends Thread {
 
         casCache = null;
 
-//        synchronized (outputQueue) { // redundant - the above enqueue call does this
-//          outputQueue.notifyAll();
-//        }
+        // synchronized (outputQueue) { // redundant - the above enqueue call does this
+        // outputQueue.notifyAll();
+        // }
 
       }
       return;
@@ -1313,7 +1326,8 @@ public class ProcessingUnit extends Thread {
       if (outputQueue == null && casObjects != null && casObjects instanceof CasData[]) {
         if (System.getProperty("DEBUG_RELEASE") != null) {
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            logFinest("UIMA_CPM_done_with_cas__FINEST", String.valueOf(Runtime.getRuntime().freeMemory() / 1024));  
+            logFinest("UIMA_CPM_done_with_cas__FINEST",
+                    String.valueOf(Runtime.getRuntime().freeMemory() / 1024));
           }
         }
         for (int i = 0; i < casObjects.length; i++) {
@@ -1322,9 +1336,10 @@ public class ProcessingUnit extends Thread {
           aCasObjectList[i] = null;
           maybeLogFinest("UIMA_CPM_show_local_cache__FINEST", casCache);
         }
-        if (System.getProperty("DEBUG_RELEASE") != null) {          
+        if (System.getProperty("DEBUG_RELEASE") != null) {
           if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-            logFinest("UIMA_CPM_show_total_memory__FINEST", String.valueOf(Runtime.getRuntime().freeMemory() / 1024));
+            logFinest("UIMA_CPM_show_total_memory__FINEST",
+                    String.valueOf(Runtime.getRuntime().freeMemory() / 1024));
           }
         }
       }
@@ -1336,14 +1351,14 @@ public class ProcessingUnit extends Thread {
    * container using configuration determines if its time to call Cas Processor's
    * batchProcessComplete() method.
    * 
-   * @param aContainer -
-   *          container performing end of batch processing
-   * @param aProcessor -
-   *          Cas Processor to call on end of batch
-   * @param aProcessTr -
-   *          Process Trace to use for aggregating events
-   * @param aCasObjectList -
-   *          CASes just analyzed
+   * @param aContainer
+   *          - container performing end of batch processing
+   * @param aProcessor
+   *          - Cas Processor to call on end of batch
+   * @param aProcessTr
+   *          - Process Trace to use for aggregating events
+   * @param aCasObjectList
+   *          - CASes just analyzed
    */
   private void doEndOfBatchProcessing(ProcessingContainer aContainer, CasProcessor aProcessor,
           ProcessTrace aProcessTr, Object[] aCasObjectList) {
@@ -1355,8 +1370,8 @@ public class ProcessingUnit extends Thread {
 
       maybeLogFinest("UIMA_CPM_end_of_batch_completed__FINEST", aContainer);
     } catch (Exception ex) {
-      maybeLogSevere("UIMA_CPM_end_of_batch_exception__SEVERE", 
-          aContainer.getName(), ex.getMessage());
+      maybeLogSevere("UIMA_CPM_end_of_batch_exception__SEVERE", aContainer.getName(),
+              ex.getMessage());
       aProcessTr.endEvent(cName, "End of Batch", "failed");
 
     } finally {
@@ -1373,10 +1388,14 @@ public class ProcessingUnit extends Thread {
    * In case a CAS is skipped ( due to excessive exceptions that it causes ), increments stats and
    * totals.
    *
-   * @param aContainer the a container
-   * @param aCasObjectList the a cas object list
-   * @param isLastCP the is last CP
-   * @throws Exception -
+   * @param aContainer
+   *          the a container
+   * @param aCasObjectList
+   *          the a cas object list
+   * @param isLastCP
+   *          the is last CP
+   * @throws Exception
+   *           -
    */
   private void handleSkipCasProcessor(ProcessingContainer aContainer, Object[] aCasObjectList,
           boolean isLastCP) throws Exception {
@@ -1404,7 +1423,7 @@ public class ProcessingUnit extends Thread {
         try {
           releaseCases(casList, isLastCP, aContainer.getName());
         } catch (Exception ex2) {
-          
+
           if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
             logSevere("UIMA_CPM_exception_releasing_cas__SEVERE", aContainer.getName());
             maybeLogSevereException(ex2);
@@ -1419,16 +1438,17 @@ public class ProcessingUnit extends Thread {
   /**
    * Handle exceptions related to remote invocations.
    * 
-   * @param aContainer -
-   *          container managing CasProcessor that failed
-   * @param aProcessor -
-   *          failed CasProcessor
-   * @param aProcessTr -
-   *          ProcessTrace object holding events
-   * @param ex -
-   *          Source exception
+   * @param aContainer
+   *          - container managing CasProcessor that failed
+   * @param aProcessor
+   *          - failed CasProcessor
+   * @param aProcessTr
+   *          - ProcessTrace object holding events
+   * @param ex
+   *          - Source exception
    * 
-   * @throws Exception -
+   * @throws Exception
+   *           -
    */
   private void handleServiceException(ProcessingContainer aContainer, CasProcessor aProcessor,
           ProcessTrace aProcessTr, Exception ex) throws Exception {
@@ -1450,7 +1470,7 @@ public class ProcessingUnit extends Thread {
         aProcessTr.startEvent(aContainer.getName(), "Process", "");
         // Redeploy the CasProcessor
         maybeLogFinest("UIMA_CPM_redeploy_cp__FINEST", aContainer, aProcessor);
-       // Reconnect the CPM to CasProcessor running in fenced mode
+        // Reconnect the CPM to CasProcessor running in fenced mode
         cpm.redeployAnalysisEngine(aContainer);
 
         // Resume the container
@@ -1472,16 +1492,16 @@ public class ProcessingUnit extends Thread {
   /**
    * Diables currect CasProcessor.
    * 
-   * @param aContainer -
-   *          a container that manages the current Cas Processor.
-   * @param aProcessor -
-   *          a Cas Processor to be disabled
-   * @throws Exception -
-   *           exception
+   * @param aContainer
+   *          - a container that manages the current Cas Processor.
+   * @param aProcessor
+   *          - a Cas Processor to be disabled
+   * @throws Exception
+   *           - exception
    */
   private void handleAbortCasProcessor(ProcessingContainer aContainer, CasProcessor aProcessor)
           throws Exception {
-    maybeLogFinest("UIMA_CPM_disable_due_to_action__FINEST", aContainer); 
+    maybeLogFinest("UIMA_CPM_disable_due_to_action__FINEST", aContainer);
     if (aContainer.isPaused()) {
       aContainer.resume();
     }
@@ -1499,12 +1519,12 @@ public class ProcessingUnit extends Thread {
   /**
    * Terminates the CPM.
    *
-   * @param aContainer -
-   *          a container that manages the current Cas Processor.
-   * @param aProcessor -
-   *          a Cas Processor to be disabled
-   * @throws Exception -
-   *           exception
+   * @param aContainer
+   *          - a container that manages the current Cas Processor.
+   * @param aProcessor
+   *          - a Cas Processor to be disabled
+   * @throws Exception
+   *           - exception
    */
   private void handleAbortCPM(ProcessingContainer aContainer, CasProcessor aProcessor)
           throws Exception {
@@ -1523,7 +1543,8 @@ public class ProcessingUnit extends Thread {
         releaseCAS = true;
         releaseCases(casList, true, aContainer.getName());
       } catch (Exception exc) {
-        maybeLogSevere("UIMA_CPM_exception_on_cpm_kill__WARNING", aContainer.getName(), exc.getMessage());
+        maybeLogSevere("UIMA_CPM_exception_on_cpm_kill__WARNING", aContainer.getName(),
+                exc.getMessage());
         maybeLogSevereException(exc);
       }
     }
@@ -1536,10 +1557,10 @@ public class ProcessingUnit extends Thread {
   /**
    * Terminates the CPM.
    *
-   * @param aContainer -
-   *          a container that manages the current Cas Processor.
-   * @throws Exception -
-   *           exception
+   * @param aContainer
+   *          - a container that manages the current Cas Processor.
+   * @throws Exception
+   *           - exception
    */
   private void handleKillPipeline(ProcessingContainer aContainer) throws Exception {
     if (aContainer.isPaused()) {
@@ -1565,11 +1586,12 @@ public class ProcessingUnit extends Thread {
    * initiate service restart. While the service is being restarted no invocations on the service
    * should be done. Containers will be resumed on successfull service restart.
    *
-   * @param aContainer -
-   *          a container that manages the current Cas Processor.
-   * @param aException the a exception
-   * @param aThreadId -
-   *          id of the current thread
+   * @param aContainer
+   *          - a container that manages the current Cas Processor.
+   * @param aException
+   *          the a exception
+   * @param aThreadId
+   *          - id of the current thread
    * @return true, if successful
    */
   private boolean pauseContainer(ProcessingContainer aContainer, Exception aException,
@@ -1586,18 +1608,19 @@ public class ProcessingUnit extends Thread {
    * Conditionally, releases CASes back to the CAS pool. The release only occurs if the Cas
    * Processor is the last in the processing chain.
    *
-   * @param aCasList -
-   *          list of CASes to release
-   * @param lastProcessor -
-   *          determines if the release takes place
-   * @param aName the a name
+   * @param aCasList
+   *          - list of CASes to release
+   * @param lastProcessor
+   *          - determines if the release takes place
+   * @param aName
+   *          the a name
    */
   private void releaseCases(Object aCasList, boolean lastProcessor, String aName) // ProcessingContainer
   // aContainer)
   {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-      logFinest("UIMA_CPM_releasing_cases__FINEST", 
-          aName, String.valueOf(releaseCAS), String.valueOf(lastProcessor));
+      logFinest("UIMA_CPM_releasing_cases__FINEST", aName, String.valueOf(releaseCAS),
+              String.valueOf(lastProcessor));
     }
     if (aCasList == null) {
       return;
@@ -1620,14 +1643,15 @@ public class ProcessingUnit extends Thread {
   }
 
   /**
-   * Notifies Listeners of the fact that the pipeline has finished processing the current set Cas'es.
+   * Notifies Listeners of the fact that the pipeline has finished processing the current set
+   * Cas'es.
    *
-   * @param aCas -
-   *          object containing an array of OR a single instance of Cas
-   * @param isCasObject -
-   *          true if instance of Cas is of type Cas, false otherwise
-   * @param aEntityProcStatus -
-   *          status object that may contain exceptions and trace
+   * @param aCas
+   *          - object containing an array of OR a single instance of Cas
+   * @param isCasObject
+   *          - true if instance of Cas is of type Cas, false otherwise
+   * @param aEntityProcStatus
+   *          - status object that may contain exceptions and trace
    */
   protected void notifyListeners(Object aCas, boolean isCasObject,
           EntityProcessStatus aEntityProcStatus) {
@@ -1644,12 +1668,12 @@ public class ProcessingUnit extends Thread {
    * Notifies all configured listeners. Makes sure that appropriate type of Cas is sent to the
    * listener. Convertions take place to ensure compatibility.
    * 
-   * @param aCas -
-   *          Cas to pass to listener
-   * @param isCasObject -
-   *          true is Cas is of type CAS
-   * @param aEntityProcStatus -
-   *          status object containing exceptions and trace info
+   * @param aCas
+   *          - Cas to pass to listener
+   * @param isCasObject
+   *          - true is Cas is of type CAS
+   * @param aEntityProcStatus
+   *          - status object containing exceptions and trace info
    */
   protected void doNotifyListeners(Object aCas, boolean isCasObject,
           EntityProcessStatus aEntityProcStatus) {
@@ -1689,9 +1713,10 @@ public class ProcessingUnit extends Thread {
           casObjectCopy = conversionCas;
         }
         // Notify the listener that the Cas has been processed
-//        ((StatusCallbackListener) statCL).entityProcessComplete((CAS) casObjectCopy,
-//                aEntityProcStatus);
-        CPMEngine.callEntityProcessCompleteWithCAS((StatusCallbackListener) statCL, (CAS) casObjectCopy, aEntityProcStatus);
+        // ((StatusCallbackListener) statCL).entityProcessComplete((CAS) casObjectCopy,
+        // aEntityProcStatus);
+        CPMEngine.callEntityProcessCompleteWithCAS((StatusCallbackListener) statCL,
+                (CAS) casObjectCopy, aEntityProcStatus);
         if (conversionCas != null) {
           if (casFromPool) {
             conversionCasArray[0] = conversionCas;
@@ -1713,8 +1738,8 @@ public class ProcessingUnit extends Thread {
    * at the end of processing. This is typically done for Cas Consumer thread, but in configurations
    * not using Cas Consumers The processing pipeline may also release the CAS.
    * 
-   * @param aFlag -
-   *          true if this thread should release a CAS when analysis is complete
+   * @param aFlag
+   *          - true if this thread should release a CAS when analysis is complete
    */
   public void setReleaseCASFlag(boolean aFlag) {
     releaseCAS = aFlag;
@@ -1723,25 +1748,25 @@ public class ProcessingUnit extends Thread {
   /**
    * Stops all Cas Processors that are part of this PU.
    * 
-   * @param kill -
-   *          true if CPE has been stopped before finishing processing during external stop
+   * @param kill
+   *          - true if CPE has been stopped before finishing processing during external stop
    * 
    */
   public void stopCasProcessors(boolean kill) {
     maybeLogFinest("UIMA_CPM_stop_containers__FINEST");
-   // Stop all running CASProcessors
+    // Stop all running CASProcessors
     for (int i = 0; processContainers != null && i < processContainers.size(); i++) {
       ProcessingContainer container = (ProcessingContainer) processContainers.get(i);
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-        logFinest("UIMA_CPM_show_container_time__FINEST", 
-            container.getName(), String.valueOf(container.getTotalTime()));
+        logFinest("UIMA_CPM_show_container_time__FINEST", container.getName(),
+                String.valueOf(container.getTotalTime()));
       }
       synchronized (container) {
         // Change the status of this container to KILLED if the CPM has been stopped
         // before completing the collection and current status of CasProcessor is
         // either READY or RUNNING
         if (kill || (!cpm.isRunning() && isProcessorReady(container.getStatus()))) {
-          maybeLogFinest("UIMA_CPM_kill_cp__FINEST", container);         
+          maybeLogFinest("UIMA_CPM_kill_cp__FINEST", container);
           container.setStatus(Constants.CAS_PROCESSOR_KILLED);
         } else {
           // If the CasProcessor has not been disabled during processing change its
@@ -1750,10 +1775,10 @@ public class ProcessingUnit extends Thread {
             container.setStatus(Constants.CAS_PROCESSOR_COMPLETED);
           }
         }
-        
+
         if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-          logFinest("UIMA_CPM_container_status__FINEST", 
-              container.getName(), String.valueOf(container.getStatus()));
+          logFinest("UIMA_CPM_container_status__FINEST", container.getName(),
+                  String.valueOf(container.getStatus()));
         }
         ProcessTrace pTrTemp = new ProcessTrace_impl(cpm.getPerformanceTuningSettings());
         pTrTemp.startEvent(container.getName(), "End of Batch", "");
@@ -1762,14 +1787,16 @@ public class ProcessingUnit extends Thread {
 
           if (deployer != null) {
             if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
-              logFinest("UIMA_CPM_undeploy_cp_instances__FINEST", container.getName(), deployer.getClass().getName());
+              logFinest("UIMA_CPM_undeploy_cp_instances__FINEST", container.getName(),
+                      deployer.getClass().getName());
             }
             deployer.undeploy();
           }
           container.destroy();
         } catch (Exception e) {
 
-          logWarning("UIMA_CPM_exception_during_cp_stop__WARNING", container.getName(), e.getMessage());
+          logWarning("UIMA_CPM_exception_during_cp_stop__WARNING", container.getName(),
+                  e.getMessage());
         } finally {
           pTrTemp.endEvent(container.getName(), "End of Batch", "");
           if (processingUnitProcessTrace != null) {
@@ -1783,8 +1810,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Returns true if the CPM has finished analyzing the collection.
    * 
-   * @param aCount -
-   *          running total of documents processed so far
+   * @param aCount
+   *          - running total of documents processed so far
    * 
    * @return - true if CPM has processed all docs, false otherwise
    */
@@ -1801,7 +1828,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Process.
    *
-   * @param anArtifact the an artifact
+   * @param anArtifact
+   *          the an artifact
    */
   protected void process(Object anArtifact) {
     if (anArtifact instanceof Object[]) {
@@ -1815,7 +1843,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Show metadata.
    *
-   * @param aCasList the a cas list
+   * @param aCasList
+   *          the a cas list
    */
   protected void showMetadata(Object[] aCasList) {
   }
@@ -1823,7 +1852,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Check if the CASProcessor status is available for processing.
    *
-   * @param aStatus the a status
+   * @param aStatus
+   *          the a status
    * @return true, if is processor ready
    */
   protected boolean isProcessorReady(int aStatus) {
@@ -1837,7 +1867,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Returns the size of the CAS object. Currently only CASData is supported.
    * 
-   * @param aCas CAS to get the size for
+   * @param aCas
+   *          CAS to get the size for
    * 
    * @return the size of the CAS object. Currently only CASData is supported.
    */
@@ -1855,7 +1886,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Sets the cas pool.
    *
-   * @param aPool the new cas pool
+   * @param aPool
+   *          the new cas pool
    */
   public void setCasPool(CPECasPool aPool) {
     casPool = aPool;
@@ -1864,9 +1896,12 @@ public class ProcessingUnit extends Thread {
   /**
    * Filter out the CAS.
    *
-   * @param aContainer the a container
-   * @param isCasObject the is cas object
-   * @param aCasObjectList the a cas object list
+   * @param aContainer
+   *          the a container
+   * @param isCasObject
+   *          the is cas object
+   * @param aCasObjectList
+   *          the a cas object list
    * @return true, if successful
    */
   private boolean filterOutTheCAS(ProcessingContainer aContainer, boolean isCasObject,
@@ -1887,7 +1922,8 @@ public class ProcessingUnit extends Thread {
   /**
    * Container disabled.
    *
-   * @param aContainer the a container
+   * @param aContainer
+   *          the a container
    * @return true, if successful
    */
   private boolean containerDisabled(ProcessingContainer aContainer) {
@@ -1907,12 +1943,13 @@ public class ProcessingUnit extends Thread {
   /**
    * An alternate processing loop designed for the single-threaded CPM.
    *
-   * @param aCasObjectList -
-   *          a list of CASes to analyze
-   * @param pTrTemp -
-   *          process trace where statistics are added during analysis
+   * @param aCasObjectList
+   *          - a list of CASes to analyze
+   * @param pTrTemp
+   *          - process trace where statistics are added during analysis
    * @return true, if successful
-   * @throws Exception the exception
+   * @throws Exception
+   *           the exception
    */
   protected boolean analyze(Object[] aCasObjectList, ProcessTrace pTrTemp) throws Exception // throws
   // ResourceProcessException,
@@ -1985,8 +2022,9 @@ public class ProcessingUnit extends Thread {
             maybeLogSevere("UIMA_CPM_checkout_null_cp_from_container__SEVERE", containerName);
             throw new ResourceProcessException(CpmLocalizedMessage.getLocalizedMessage(
                     CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-                    "UIMA_CPM_EXP_invalid_component_reference__WARNING", new Object[] {
-                        Thread.currentThread().getName(), "CasProcessor", "NULL" }), null);
+                    "UIMA_CPM_EXP_invalid_component_reference__WARNING",
+                    new Object[] { Thread.currentThread().getName(), "CasProcessor", "NULL" }),
+                    null);
           }
           // Check to see if the CasProcessor is available for processing
           // The CasProcessor may have been disabled due to excessive errors and error policy
@@ -2077,8 +2115,10 @@ public class ProcessingUnit extends Thread {
   /**
    * Do release cas processor.
    *
-   * @param aContainer the a container
-   * @param aCasProcessor the a cas processor
+   * @param aContainer
+   *          the a container
+   * @param aCasProcessor
+   *          the a cas processor
    */
   private void doReleaseCasProcessor(ProcessingContainer aContainer, CasProcessor aCasProcessor) {
     if (aCasProcessor != null && aContainer != null) {
@@ -2089,10 +2129,14 @@ public class ProcessingUnit extends Thread {
   /**
    * Do end of batch.
    *
-   * @param aContainer the a container
-   * @param aProcessor the a processor
-   * @param aProcessTr the a process tr
-   * @param howManyCases the how many cases
+   * @param aContainer
+   *          the a container
+   * @param aProcessor
+   *          the a processor
+   * @param aProcessTr
+   *          the a process tr
+   * @param howManyCases
+   *          the how many cases
    */
   private void doEndOfBatch(ProcessingContainer aContainer, CasProcessor aProcessor,
           ProcessTrace aProcessTr, int howManyCases) {
@@ -2101,38 +2145,39 @@ public class ProcessingUnit extends Thread {
       aContainer.isEndOfBatch(aProcessor, howManyCases);
       maybeLogFinest("UIMA_CPM_end_of_batch_completed__FINEST", aContainer);
     } catch (Exception ex) {
-        maybeLogSevere("UIMA_CPM_end_of_batch_exception__SEVERE", containerName, ex.getMessage());
+      maybeLogSevere("UIMA_CPM_end_of_batch_exception__SEVERE", containerName, ex.getMessage());
     }
   }
 
   /**
    * Main routine that handles errors occuring in the processing loop.
    * 
-   * @param e -
-   *          exception in the main processing loop
-   * @param aContainer -
-   *          current container of the Cas Processor
-   * @param aProcessor -
-   *          current Cas Processor
-   * @param aProcessTrace -
-   *          an object containing stats for this procesing loop
-   * @param aCasObjectList -
-   *          list of CASes being analyzed
-   * @param isCasObject -
-   *          determines type of CAS in the aCasObjectList ( CasData or CasObject)
+   * @param e
+   *          - exception in the main processing loop
+   * @param aContainer
+   *          - current container of the Cas Processor
+   * @param aProcessor
+   *          - current Cas Processor
+   * @param aProcessTrace
+   *          - an object containing stats for this procesing loop
+   * @param aCasObjectList
+   *          - list of CASes being analyzed
+   * @param isCasObject
+   *          - determines type of CAS in the aCasObjectList ( CasData or CasObject)
    * @return boolean
-   * @throws Exception -
+   * @throws Exception
+   *           -
    */
-  private boolean handleErrors(Throwable e, ProcessingContainer aContainer,
-          CasProcessor aProcessor, ProcessTrace aProcessTrace, Object[] aCasObjectList,
-          boolean isCasObject) throws Exception {
+  private boolean handleErrors(Throwable e, ProcessingContainer aContainer, CasProcessor aProcessor,
+          ProcessTrace aProcessTrace, Object[] aCasObjectList, boolean isCasObject)
+          throws Exception {
     boolean retry = true;
 
     String containerName = aContainer.getName();
     e.printStackTrace();
     maybeLogSevereException(e);
-    maybeLogSevere("UIMA_CPM_handle_exception__SEVERE", 
-        containerName, aProcessor.getClass().getName(), e.getMessage());
+    maybeLogSevere("UIMA_CPM_handle_exception__SEVERE", containerName,
+            aProcessor.getClass().getName(), e.getMessage());
 
     EntityProcessStatusImpl enProcSt = new EntityProcessStatusImpl(aProcessTrace);
     enProcSt.addEventStatus("Process", "Failed", e);
@@ -2232,15 +2277,12 @@ public class ProcessingUnit extends Thread {
     } catch (Exception ex) {
       maybeLogSevereException(ex);
       if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
-        // done as 2 messages because there is no method supporting 
+        // done as 2 messages because there is no method supporting
         // both a Throwable, and a message with substitutable args, in the logger
         logSevere("UIMA_CPM_unhandled_error__SEVERE", e.getLocalizedMessage());
-        UIMAFramework.getLogger(this.getClass()).logrb(Level.SEVERE,
-            this.getClass().getName(),
-            "handleErrors",
-            CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-            "UIMA_CPM_unexpected_exception__SEVERE",
-            ex);     
+        UIMAFramework.getLogger(this.getClass()).logrb(Level.SEVERE, this.getClass().getName(),
+                "handleErrors", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+                "UIMA_CPM_unexpected_exception__SEVERE", ex);
       }
       retry = false;
       ex.printStackTrace();
@@ -2251,12 +2293,18 @@ public class ProcessingUnit extends Thread {
   /**
    * Invoke cas object cas processor.
    *
-   * @param container the container
-   * @param processor the processor
-   * @param aCasObjectList the a cas object list
-   * @param pTrTemp the tr temp
-   * @param isCasObject the is cas object
-   * @throws Exception -
+   * @param container
+   *          the container
+   * @param processor
+   *          the processor
+   * @param aCasObjectList
+   *          the a cas object list
+   * @param pTrTemp
+   *          the tr temp
+   * @param isCasObject
+   *          the is cas object
+   * @throws Exception
+   *           -
    */
   private void invokeCasObjectCasProcessor(ProcessingContainer container, CasProcessor processor,
           Object[] aCasObjectList, ProcessTrace pTrTemp, boolean isCasObject) throws Exception {
@@ -2267,11 +2315,8 @@ public class ProcessingUnit extends Thread {
       maybeLogFinest("UIMA_CPM_initialize_cas__FINEST", container);
       if (aCasObjectList[casIndex] == null) {
         if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
-          UIMAFramework.getLogger(this.getClass()).logrb(
-                  Level.SEVERE,
-                  this.getClass().getName(),
-                  "process",
-                  CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
+          UIMAFramework.getLogger(this.getClass()).logrb(Level.SEVERE, this.getClass().getName(),
+                  "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
                   "UIMA_CPM_casobjectlist_is_null__SEVERE",
                   new Object[] { Thread.currentThread().getName(), container.getName(),
                       String.valueOf(casIndex) });
@@ -2305,10 +2350,14 @@ public class ProcessingUnit extends Thread {
   /**
    * Convert cas data to cas object.
    *
-   * @param casIndex the cas index
-   * @param aContainerName the a container name
-   * @param aCasObjectList the a cas object list
-   * @throws Exception -
+   * @param casIndex
+   *          the cas index
+   * @param aContainerName
+   *          the a container name
+   * @param aCasObjectList
+   *          the a cas object list
+   * @throws Exception
+   *           -
    */
   private void convertCasDataToCasObject(int casIndex, String aContainerName,
           Object[] aCasObjectList) throws Exception {
@@ -2342,13 +2391,20 @@ public class ProcessingUnit extends Thread {
   /**
    * Invoke cas data cas processor.
    *
-   * @param container the container
-   * @param processor the processor
-   * @param aCasObjectList the a cas object list
-   * @param pTrTemp the tr temp
-   * @param isCasObject the is cas object
-   * @param retry the retry
-   * @throws Exception -
+   * @param container
+   *          the container
+   * @param processor
+   *          the processor
+   * @param aCasObjectList
+   *          the a cas object list
+   * @param pTrTemp
+   *          the tr temp
+   * @param isCasObject
+   *          the is cas object
+   * @param retry
+   *          the retry
+   * @throws Exception
+   *           -
    */
   private void invokeCasDataCasProcessor(ProcessingContainer container, CasProcessor processor,
           Object[] aCasObjectList, ProcessTrace pTrTemp, boolean isCasObject, boolean retry)
@@ -2404,21 +2460,26 @@ public class ProcessingUnit extends Thread {
     }
     pTrTemp.endEvent(container.getName(), "Process", "success");
   }
-  
- 
-  /** loggers   Special forms for frequent args sets   "maybe" versions test isLoggable      Additional args passed as object array to logger. */
-  
-  private static final Object [] zeroLengthObjectArray = new Object[0];
-  
+
+  /**
+   * loggers Special forms for frequent args sets "maybe" versions test isLoggable Additional args
+   * passed as object array to logger.
+   */
+
+  private static final Object[] zeroLengthObjectArray = new Object[0];
+
   /** The Constant thisClassName. */
   private static final String thisClassName = ProcessingUnit.class.getName();
-  
+
   /**
    * Log CPM.
    *
-   * @param level the level
-   * @param msgBundleId the msg bundle id
-   * @param args the args
+   * @param level
+   *          the level
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param args
+   *          the args
    */
   private void logCPM(Level level, String msgBundleId, Object[] args) {
     if (null == args) {
@@ -2427,21 +2488,17 @@ public class ProcessingUnit extends Thread {
     Object[] aa = new Object[args.length + 1];
     aa[0] = Thread.currentThread().getName();
     System.arraycopy(args, 0, aa, 1, args.length);
-  
-    UIMAFramework.getLogger(this.getClass()).logrb(
-        level,
-        thisClassName,
-        "process",  // used as the method name
-        CPMUtils.CPM_LOG_RESOURCE_BUNDLE,
-        msgBundleId,
-        aa
-        );
+
+    UIMAFramework.getLogger(this.getClass()).logrb(level, thisClassName, "process", // used as the
+                                                                                    // method name
+            CPMUtils.CPM_LOG_RESOURCE_BUNDLE, msgBundleId, aa);
   }
 
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
+   * @param msgBundleId
+   *          the msg bundle id
    */
   // 0 arg
   private void maybeLogFinest(String msgBundleId) {
@@ -2449,21 +2506,24 @@ public class ProcessingUnit extends Thread {
       logFinest(msgBundleId);
     }
   }
-  
+
   /**
    * Log finest.
    *
-   * @param msgBundleId the msg bundle id
+   * @param msgBundleId
+   *          the msg bundle id
    */
   private void logFinest(String msgBundleId) {
     logCPM(Level.FINEST, msgBundleId, null);
   }
- 
+
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
    */
   // 1 arg
   private void maybeLogFinest(String msgBundleId, String arg1) {
@@ -2471,23 +2531,28 @@ public class ProcessingUnit extends Thread {
       logFinest(msgBundleId, arg1);
     }
   }
-  
+
   /**
    * Log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
    */
   private void logFinest(String msgBundleId, String arg1) {
-    logCPM(Level.FINEST, msgBundleId, new Object [] {arg1});
+    logCPM(Level.FINEST, msgBundleId, new Object[] { arg1 });
   }
 
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   // 2 args
   private void maybeLogFinest(String msgBundleId, String arg1, String arg2) {
@@ -2495,110 +2560,134 @@ public class ProcessingUnit extends Thread {
       logFinest(msgBundleId, arg1, arg2);
     }
   }
-  
+
   /**
    * Log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   private void logFinest(String msgBundleId, String arg1, String arg2) {
-    logCPM(Level.FINEST, msgBundleId, new Object [] {arg1, arg2});
+    logCPM(Level.FINEST, msgBundleId, new Object[] { arg1, arg2 });
   }
-  
+
   // 3 args
-  
+
   /**
    * Log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
-   * @param arg3 the arg 3
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
+   * @param arg3
+   *          the arg 3
    */
   private void logFinest(String msgBundleId, String arg1, String arg2, String arg3) {
-    logCPM(Level.FINEST, msgBundleId, new Object [] {arg1, arg2, arg3});
+    logCPM(Level.FINEST, msgBundleId, new Object[] { arg1, arg2, arg3 });
   }
-
 
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param container the container
-   * @param processor the processor
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param container
+   *          the container
+   * @param processor
+   *          the processor
    */
   // special common 2 arg version with container, processor
-  private void maybeLogFinest(String msgBundleId, ProcessingContainer container, CasProcessor processor) {
+  private void maybeLogFinest(String msgBundleId, ProcessingContainer container,
+          CasProcessor processor) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
       logFinest(msgBundleId, container.getName(), processor.getClass().getName());
     }
   }
-  
+
   /**
    * Log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param container the container
-   * @param processor the processor
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param container
+   *          the container
+   * @param processor
+   *          the processor
    */
-  private void logFinest(String msgBundleId, ProcessingContainer container, CasProcessor processor) {
+  private void logFinest(String msgBundleId, ProcessingContainer container,
+          CasProcessor processor) {
     logFinest(msgBundleId, container.getName(), processor.getClass().getName());
   }
-  
+
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param container the container
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param container
+   *          the container
    */
   private void maybeLogFinest(String msgBundleId, ProcessingContainer container) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
       logFinest(msgBundleId, container.getName());
     }
   }
-  
+
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param processor the processor
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param processor
+   *          the processor
    */
   private void maybeLogFinest(String msgBundleId, CasProcessor processor) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
       logFinest(msgBundleId, processor.getClass().getName());
     }
   }
-  
+
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param container the container
-   * @param processor the processor
-   * @param casCache the cas cache
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param container
+   *          the container
+   * @param processor
+   *          the processor
+   * @param casCache
+   *          the cas cache
    */
-  private void maybeLogFinest(String msgBundleId, ProcessingContainer container, CasProcessor processor, CAS [] casCache) {
+  private void maybeLogFinest(String msgBundleId, ProcessingContainer container,
+          CasProcessor processor, CAS[] casCache) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
       logFinest(msgBundleId, container.getName(), processor.getClass().getName(),
-          String.valueOf(casCache == null));
+              String.valueOf(casCache == null));
     }
   }
-  
+
   /**
    * Maybe log finest.
    *
-   * @param msgBundleId the msg bundle id
-   * @param casCache the cas cache
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param casCache
+   *          the cas cache
    */
-  private void maybeLogFinest(String msgBundleId, CAS [] casCache) {
+  private void maybeLogFinest(String msgBundleId, CAS[] casCache) {
     if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {
       logFinest(msgBundleId, String.valueOf(casCache == null));
     }
   }
 
-  
   /**
    * Maybe log memory finest.
    */
@@ -2607,20 +2696,21 @@ public class ProcessingUnit extends Thread {
       logMemoryFinest();
     }
   }
-  
+
   /**
    * Log memory finest.
    */
   private void logMemoryFinest() {
-    logFinest("UIMA_CPM_show_memory__FINEST", 
-          String.valueOf(Runtime.getRuntime().totalMemory() / 1024),
-          String.valueOf(Runtime.getRuntime().freeMemory() / 1024));
+    logFinest("UIMA_CPM_show_memory__FINEST",
+            String.valueOf(Runtime.getRuntime().totalMemory() / 1024),
+            String.valueOf(Runtime.getRuntime().freeMemory() / 1024));
   }
 
   /**
    * Log warning.
    *
-   * @param msgBundleId the msg bundle id
+   * @param msgBundleId
+   *          the msg bundle id
    */
   private void logWarning(String msgBundleId) {
     logCPM(Level.WARNING, msgBundleId, null);
@@ -2629,31 +2719,38 @@ public class ProcessingUnit extends Thread {
   /**
    * Maybe log warning.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   private void maybeLogWarning(String msgBundleId, String arg1, String arg2) {
     if (UIMAFramework.getLogger().isLoggable(Level.WARNING)) {
       logWarning(msgBundleId, arg1, arg2);
     }
   }
-  
+
   /**
    * Log warning.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   private void logWarning(String msgBundleId, String arg1, String arg2) {
-    logCPM(Level.WARNING, msgBundleId, new Object [] {arg1, arg2});
+    logCPM(Level.WARNING, msgBundleId, new Object[] { arg1, arg2 });
   }
-  
+
   /**
    * Maybe log severe.
    *
-   * @param msgBundleId the msg bundle id
+   * @param msgBundleId
+   *          the msg bundle id
    */
   private void maybeLogSevere(String msgBundleId) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
@@ -2661,97 +2758,117 @@ public class ProcessingUnit extends Thread {
     }
   }
 
-  
   /**
    * Maybe log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
    */
   private void maybeLogSevere(String msgBundleId, String arg1) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
       logSevere(msgBundleId, arg1);
     }
   }
-  
+
   /**
    * Log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
    */
   private void logSevere(String msgBundleId, String arg1) {
-    logCPM(Level.SEVERE, msgBundleId, new Object[] {arg1});
+    logCPM(Level.SEVERE, msgBundleId, new Object[] { arg1 });
   }
 
-  
   /**
    * Maybe log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   private void maybeLogSevere(String msgBundleId, String arg1, String arg2) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
       logSevere(msgBundleId, arg1, arg2);
     }
   }
-  
+
   /**
    * Log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
    */
   private void logSevere(String msgBundleId, String arg1, String arg2) {
-    logCPM(Level.SEVERE, msgBundleId, new Object[] {arg1, arg2});
+    logCPM(Level.SEVERE, msgBundleId, new Object[] { arg1, arg2 });
   }
 
   /**
    * Maybe log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
-   * @param arg3 the arg 3
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
+   * @param arg3
+   *          the arg 3
    */
   private void maybeLogSevere(String msgBundleId, String arg1, String arg2, String arg3) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
       logSevere(msgBundleId, arg1, arg2, arg3);
     }
   }
-  
+
   /**
    * Log severe.
    *
-   * @param msgBundleId the msg bundle id
-   * @param arg1 the arg 1
-   * @param arg2 the arg 2
-   * @param arg3 the arg 3
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param arg1
+   *          the arg 1
+   * @param arg2
+   *          the arg 2
+   * @param arg3
+   *          the arg 3
    */
   private void logSevere(String msgBundleId, String arg1, String arg2, String arg3) {
-    logCPM(Level.SEVERE, msgBundleId, new Object[] {arg1, arg2, arg3});
+    logCPM(Level.SEVERE, msgBundleId, new Object[] { arg1, arg2, arg3 });
   }
-  
+
   /**
    * Maybe log severe exception.
    *
-   * @param e the e
+   * @param e
+   *          the e
    */
   private void maybeLogSevereException(Throwable e) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {
-      String m = "Thread: " + Thread.currentThread().getName() + ", message: " +  e.getLocalizedMessage();
+      String m = "Thread: " + Thread.currentThread().getName() + ", message: "
+              + e.getLocalizedMessage();
       UIMAFramework.getLogger().log(Level.SEVERE, m, e);
     }
   }
-  
+
   /**
    * Maybe log finest work queue.
    *
-   * @param msgBundleId the msg bundle id
-   * @param workQueue the work queue
+   * @param msgBundleId
+   *          the msg bundle id
+   * @param workQueue
+   *          the work queue
    */
   private void maybeLogFinestWorkQueue(String msgBundleId, BoundedWorkQueue workQueue) {
     if (UIMAFramework.getLogger().isLoggable(Level.SEVERE)) {

--- a/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ProcessingUnit.java
+++ b/uimaj-cpe/src/main/java/org/apache/uima/collection/impl/cpm/engine/ProcessingUnit.java
@@ -62,15 +62,13 @@ import org.apache.uima.util.UimaTimer;
 import org.apache.uima.util.impl.ProcessTrace_impl;
 
 /**
- * This component executes the processing pipeline. Running in a seperate thread it continuously
- * reads bundles of Cas from the Work Queue filled by {@link ArtifactProducer} and sends it through
+ * This component executes the processing pipeline. Running in a separate thread it continuously
+ * reads bundles of CAS from the Work Queue filled by {@link ArtifactProducer} and sends it through
  * configured CasProcessors. The sequence in which CasProcessors are invoked is defined by the order
- * of Cas Processor listing in the cpe descriptor. The results of analysis produced be Cas
- * Processors is enqueued onto an output queue that is shared with Cas Consumers.
- * 
- * 
+ * of CAS Processor listing in the CPE descriptor. The results of analysis produced be CAS
+ * Processors is enqueued onto an output queue that is shared with CAS Consumers.
  */
-public class ProcessingUnit extends Thread {
+public class ProcessingUnit implements Runnable {
 
   /** The thread state. */
   public int threadState = 0;
@@ -156,6 +154,8 @@ public class ProcessingUnit extends Thread {
   /** The timer 06. */
   public long timer06 = 0;
 
+  private String name;
+
   /**
    * Instantiates a new processing unit.
    */
@@ -163,6 +163,14 @@ public class ProcessingUnit extends Thread {
     conversionCasArray = new CAS[1];
     // Instantiate a class responsible for converting CasData to CasObject and vice versa
     mConverter = new CasConverter();
+  }
+
+  public void setName(String aName) {
+    name = aName;
+  }
+
+  public String getName() {
+    return name;
   }
 
   /**
@@ -526,19 +534,19 @@ public class ProcessingUnit extends Thread {
     Thread.currentThread().setName(getName());
 
     if (!cpm.isRunning()) {
-
       UIMAFramework.getLogger(this.getClass()).logrb(Level.WARNING, this.getClass().getName(),
               "process", CPMUtils.CPM_LOG_RESOURCE_BUNDLE, "UIMA_CPM_cpm_not_running__WARNING",
               new Object[] { Thread.currentThread().getName() });
       return;
     }
+
     maybeLogFinestWorkQueue("UIMA_CPM_start_pp__FINEST", workQueue);
     // Assign initial status to all Cas Processors in the processing pipeline
     for (int i = 0; i < processContainers.size(); i++) {
       ((ProcessingContainer) processContainers.get(i)).setStatus(Constants.CAS_PROCESSOR_RUNNING);
     }
+
     // Continue until CPE is stopped
-    boolean run = true;
     int maxWaitTimeForEntity = 0;
     if (cpeConfiguration != null && cpeConfiguration.getMaxTimeToWait() > 0) {
       maxWaitTimeForEntity = cpeConfiguration.getMaxTimeToWait();
@@ -546,6 +554,7 @@ public class ProcessingUnit extends Thread {
 
     isRunning = true;
 
+    boolean run = true;
     while (run) {
       threadState = 2000; // Start the Loop
       // blocks if CPM is in pause state
@@ -564,13 +573,13 @@ public class ProcessingUnit extends Thread {
         entity = workQueue.dequeue(maxWaitTimeForEntity);
       } else {
         entity = workQueue.dequeue(0);
-
       }
 
       if (entity == null) {
         maybeLogFinest("UIMA_CPM_queue_empty__FINEST", workQueue.getName());
         continue;
       }
+
       try {
         if (entity instanceof WorkUnit) {
           artifact = (Object[]) ((WorkUnit) entity).get();
@@ -644,12 +653,10 @@ public class ProcessingUnit extends Thread {
         threadState = 2003; // Killing
 
         this.cpm.killIt();
-
       } finally {
         if (releaseCAS) {
           clearCasCache();
         }
-
       }
     }
     maybeLogFinestWorkQueue("UIMA_CPM_exit_pp__FINEST", workQueue);
@@ -657,7 +664,6 @@ public class ProcessingUnit extends Thread {
     clearCasCache();
     maybeLogFinest("UIMA_CPM_pp_terminated__FINEST");
     isRunning = false;
-
   }
 
   /**
@@ -682,7 +688,6 @@ public class ProcessingUnit extends Thread {
       }
       casCache = null;
     }
-
   }
 
   /**
@@ -722,9 +727,9 @@ public class ProcessingUnit extends Thread {
   }
 
   /**
-   * Executes the processing pipeline. Given bundle of Cas instances is processed by each Cas
-   * Processor in the pipeline. Conversions between different types of Cas Processors is done on the
-   * fly. Two types of Cas Processors are currently supported:
+   * Executes the processing pipeline. Given bundle of CAS instances is processed by each CAS
+   * Processor in the pipeline. Conversions between different types of CAS Processors is done on the
+   * fly. Two types of CAS Processors are currently supported:
    * 
    * <ul>
    * <li>CasDataProcessor</li>
@@ -732,10 +737,10 @@ public class ProcessingUnit extends Thread {
    * </ul>
    * 
    * The first operates on instances of CasData the latter operates on instances of CAS. The results
-   * produced by Cas Processors are added to the output queue.
+   * produced by CAS Processors are added to the output queue.
    *
    * @param aCasObjectList
-   *          - bundle of Cas to analyze
+   *          - bundle of CAS to analyze
    * @param pTrTemp
    *          - object used to aggregate stats
    * @return true, if successful
@@ -777,7 +782,7 @@ public class ProcessingUnit extends Thread {
     // *******************************************
     // ** P R O C E S S I N G P I P E L I N E **
     // *******************************************
-    // Send Cas Object through the processing pipeline.
+    // Send CAS Object through the processing pipeline.
     for (int i = 0; processContainers != null && i < processContainers.size(); i++) {
 
       if (UIMAFramework.getLogger().isLoggable(Level.FINEST)) {

--- a/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
+++ b/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
@@ -21,1468 +21,1448 @@
 #Messages written to log file by cpm implementation 
 #---------------------------------------------------------
 UIMA_CPM_EXP_bad_transport__WARNING = The transport class cannot be instantiated. Check the <deploymentParameters> for a missing or bad transport configuration. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_no_cpe_descriptor__WARNING = The CPE descriptor is not provided. Provide a CPE descriptor. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_invalid_impl__WARNING = The custom implementations of the CPE description are not allowed. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_invalid_cpe_descriptor_stream__WARNING = The CPE descriptor stream is not defined. Provide a CPE descriptor stream. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_bad_cpe_descriptor__WARNING = The CPE descriptor is invalid. Check for a missing CAS processor list. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_duplicate_name__WARNING = The CPE descriptor is invalid. Duplicate names are not allowed for components. The component {1} must be unique. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_instantiation_exception__WARNING = The component {1} cannot be created. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_invalid_service_descriptor__WARNING = The client service descriptor is invalid. Check for a missing <protocol> definition in component {1}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_deploy_params_not_defined__WARNING = The CPE descriptor is invalid. A deployment parameter {2} is required for the component {1}.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_no_proxy__WARNING = No proxy is available. Instantiate a proxy before calling process().  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_service_down__WARNING = The service is down.  \
-  (Thread Name: {0})  Service Endpoint: {1}
+  (Thread: {0})  Service Endpoint: {1}
 
 UIMA_CPM_EXP_configured_to_abort__WARNING = The CAS processor {1} is configured to stop the CPM when excessive errors are encountered.  \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_service_not_defined__WARNING = The service {1} is not defined.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_queue_size_not_defined__WARNING = A queue size is not defined.  \
   Check the CPE descriptor for the CAS processors attribute name {1}. \
-    (Thread Name: {0})  
+    (Thread: {0})  
 
 
 UIMA_CPM_EXP_not_directory__WARNING = {1} is not a directory.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_invalid_reference__WARNING = The object reference {1} is invalid.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_invalid_component_reference__WARNING = The component reference {2} for component {1} is invalid.  \
-  (Thread Name: {0})  
+  (Thread: {0})  
 
 UIMA_CPM_EXP_configured_to_disable__WARNING = The CAS processor {1} is configured to disable itself if excessive errors are encountered.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_configured_to_kill_pipeline__WARNING = The CAS processor {1} is configured to stop the pipeline if excessive errors are encountered.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_instantiation_problem__WARNING = The component {1} cannot be instantiated.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_invalid_array_index__WARNING = The index is invalid because it exceeds the number of available CAS processors.  \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_cp_not_in_failed_list__WARNING = A CAS processor instance cannot be found in the list of CAS processors scheduled for restart. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_no_service_port__WARNING = A valid service port cannot be acquired.  \
-  (Thread Name: {0})  
+  (Thread: {0})  
   
 UIMA_CPM_EXP_timeout_no_service_port__WARNING = A valid port cannot be acquired in the given time frame {1}.  \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_invalid_service_port__WARNING = The acquired service port {1} is invalid. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_missing_xml_element__WARNING = The CPE descriptor is invalid. Check for the missing element {2} in \
-   the configuration of the CAS processor {1}. (Thread Name: {0})
+   the configuration of the CAS processor {1}. (Thread: {0})
 
 UIMA_CPM_EXP_missing_required_element__WARNING = The CPE descriptor is invalid. Check for the missing element {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_invalid_param_settings__WARNING = The CPE descriptor is invalid. Check the \
   type {3} of the configuration parameter settings element {2} of component {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_incompatible_component__WARNING = The component {1} is incompatible. {2} is expected but {3} was obtained. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 
 UIMA_CPM_EXP_missing_attribute_from_xml_element__WARNING = The CPE descriptor is invalid. Check for the missing \
   attribute {2} in the element {3} of the CAS processor configuration {1}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_bad_action_string__WARNING = The CPE descriptor is invalid. The value action string \
   in element {2} of the CAS processor {1} is invalid. \
   [continue|terminate|disable] is expected but {3} was obtained. \
-    (Thread Name: {0}) 
+    (Thread: {0}) 
 
 UIMA_CPM_Exception_invalid_deployment__WARNING = The CPE descriptor is invalid. The deployment type for the CAS processor {1} is invalid. [local|remote|integrated] is expected but {2} was obtained. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_invalid_retry_count__WARNING = The system cannot connect to the Vinci Service. \
-  (Thread Name: {0}) Host: {1} Port: {2}. Check the value of DCONNECT_RETRY_COUNT. The supplied number is invalid.
+  (Thread: {0}) Host: {1} Port: {2}. Check the value of DCONNECT_RETRY_COUNT. The supplied number is invalid.
 
 UIMA_CPM_EXP_unable_to_connect__WARNING = The system cannot connect to the Vinci Service. \
-  (Thread Name: {0}) Host: {1} Port: {2}. 
+  (Thread: {0}) Host: {1} Port: {2}. 
 
 UIMA_CPM_EXP_service_timeout__WARNING = The service did not complete a call within the specified time. \
-  (Thread Name: {0}) Host: {1} Port: {2} Exceeded Timeout Value: {3} 
+  (Thread: {0}) Host: {1} Port: {2} Exceeded Timeout Value: {3} 
 
 UIMA_CPM_EXP_unable_to_connect_toservice__WARNING = The system is unable to connect to the Vinci Service {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_EXP_vinci_vns_cfg_invalid__WARNING = The VNS_HOST or VNS_PORT are not provided. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_target_checkpoint_not_defined__WARNING = The target to checkpoint is not defined. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_invalid_cpm__WARNING = The CPM instance is not valid (NULL). \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_bad_error_ratio__WARNING = The CPE descriptor is invalid. The ErrorRateThreshold (error count) is not defined correctly in the CPE descriptor. \
-  (Thread Name: {0}) Check the configuration of the CAS processor {1}. The ratio contains a non-digit. Define it as [error count]/[sample size], where [error count] < [sample size].
+  (Thread: {0}) Check the configuration of the CAS processor {1}. The ratio contains a non-digit. Define it as [error count]/[sample size], where [error count] < [sample size].
 
 UIMA_CPM_EXP_bad_cpe_descriptor_no_cp__WARNING = The CPE descriptor is invalid. The CAS processor configuration cannot be found. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_EXP_missing_cp__WARNING = The CAS processor configuration for the CAS processor {1} cannot be found. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_deploy_services__FINEST = Deploying Services \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_unable_to_read_meta__SEVERE = The name of the CAS processor cannot be retrieved. The meta data cannot be accessed. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_container_configuration_not_found__SEVERE = The configuration from the CAS processor container cannot be retrieved. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_casprocessor_no_name_found__SEVERE = The CPM descriptor for the CAS processor is invalid. Define a name for this CAS processor. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_deploying_service__FINEST = Deploying Service \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_deploying_service__FINEST = Deploying Service \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_no_service_connection__SEVERE = The system cannot connect to the service port {1}. \
-  (Thread Name: {0}) Service Host: {2} CAS Processor Name: {3}
+  (Thread: {0}) Service Host: {2} CAS Processor Name: {3}
 
 UIMA_CPM_restart_exceeded__WARNING = The Max Restart Count value {2} exceeds the allowed limit. \
-  (Thread Name: {0}) Service Name: {1} 
+  (Thread: {0}) Service Name: {1} 
 
 UIMA_CPM_actionon_restart_exceeded__FINEST = Action on failed restart \
-  (Thread Name: {0}) Service Name: {1} Action Max Restart Count {2}
+  (Thread: {0}) Service Name: {1} Action Max Restart Count {2}
 
 UIMA_CPM_terminate_onerrors__INFO = The CPE stopped because the CAS processor {1} has produced too many errors. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_terminate_pipeline__INFO = The CPE pipeline stopped because the CAS processor {1} has produced too many errors. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_no_action_taken__INFO = The CAS processor {1} is configured to ignore errors. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_invalid_deployment__SEVERE = The URI specifier {3} in the service descriptor {2} of the CAS processor {1} is invalid. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_disable_cp__INFO = CAS processor {1} is disabled because the service is not running. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_unable_to_deploy_service__SEVERE = The CAS processor {1} cannot be deployed. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_deploy_with_mode__FINEST = Deploying CasProcessor: \
-  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+  (Thread: {0}) CAS Processor Name: {1} Using: {2} Deployment
 
-UIMA_CPM_cp_with_exclusive_access__FINEST = Cas Processor configured for exclusive access. \
-  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+UIMA_CPM_cp_with_exclusive_access__FINEST = CAS Processor configured for exclusive access. \
+  (Thread: {0}) CAS Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_no_service_in_vns__FINEST = Unable to find vinci service in the VNS. \
-  (Thread Name: {0}) Vinci Service Name: {1} Using: {2} Deployment. Using VNS_HOST: {3} and VNS_PORT:{4}
+  (Thread: {0}) Vinci Service Name: {1} Using: {2} Deployment. Using VNS_HOST: {3} and VNS_PORT:{4}
 
-UIMA_CPM_retrieve_cp_from_failed_cplist__FINEST = Retrieving Cas Processor instance from the list of failed cas processors. \
-  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+UIMA_CPM_retrieve_cp_from_failed_cplist__FINEST = Retrieving CAS Processor instance from the list of failed cas processors. \
+  (Thread: {0}) CAS Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_connecting_to_service__FINEST = Attempting Connection to Remote Service. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_got_port_from_queue__INFO = The next port {1} was retrieved from the service port queue. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_invalid_retry_count__INFO = The value of DCONN_RETRY_COUNT is invalid. Check the command line. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_service_port_not_allocated__INFO = The service port is not available yet. There are {1} retries left to acquire the port. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_binding_to_service__FINEST = Binding Proxy to Service. \
-  (Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
+  (Thread: {0}) CAS Processor Name: {1} Service Host: {2} Service Port: {3}
 
-UIMA_CPM_no_cp_instance_in_failed_list__FINEST = Unable to acquire Cas Processor instance from the Failed Cas Processor Pool. \
-  (Thread Name: {0}) Cas Processor Name: {1} Service Host: {2} Service Port: {3}
+UIMA_CPM_no_cp_instance_in_failed_list__FINEST = Unable to acquire CAS Processor instance from the Failed CAS Processor Pool. \
+  (Thread: {0}) CAS Processor Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_already_allocated__FINEST = Already Allocated and Connected to Service. \
-  (Thread Name: {0}) Current Instance Index: {1}
+  (Thread: {0}) Current Instance Index: {1}
 
 UIMA_CPM_assign_cp_to_service__FINEST = Assigning CasProcessor to Service. \
-  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3}
+  (Thread: {0}) Service Index: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_connection_established__FINEST = Connection Established with Remote Service. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_get_cp_from_pool_error__SEVERE= There are no CAS processors in the CAS processor pool. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} Currently available CAS processor instances in pool: {3}
+  (Thread: {0}) Service Host: {1} Service Port: {2} Currently available CAS processor instances in pool: {3}
 
 UIMA_CPM_get_cp_from_pool__FINEST = Checking Out Instance of CasProcessor From Pool. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} Currently Available in Pool: {3} CP Instances
+  (Thread: {0}) Service Host: {1} Service Port: {2} Currently Available in Pool: {3} CP Instances
 
 UIMA_CPM_checkin_cp_to_pool__FINEST = Checking-In Instance of CasProcessor to Pool. \
-  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
+  (Thread: {0}) Service Index: {1} Service Host: {2} Service Port: {3} 
 
 
 UIMA_CPM_checked_in_cp_to_pool__FINEST = Checked-In Instance of CasProcessor to Pool. \
-  (Thread Name: {0}) Service Indedx: {1} Service Host: {2} Service Port: {3} 
+  (Thread: {0}) Service Index: {1} Service Host: {2} Service Port: {3} 
 
 UIMA_CPM_max_connect_retries_exceeded__FINEST = Service Connection Exception. Max number of retries reached. \
-  (Thread Name: {0}) Service Name: {1} Max Retry Count: {2}
+  (Thread: {0}) Service Name: {1} Max Retry Count: {2}
 
 UIMA_CPM_activating_service__FINEST = Activating Service Proxy. \
-  (Thread Name: {0}) Cas Processor Name: {1} Proxy {2} of {3}
+  (Thread: {0}) CAS Processor Name: {1} Proxy {2} of {3}
 
 UIMA_CPM_thread_count__FINEST = Concurrent Processing Pipeline Count. \
-  (Thread Name: {0}) Cas Processor Name: {1} Pipeling Count: {2}
+  (Thread: {0}) CAS Processor Name: {1} Pipeling Count: {2}
 
 UIMA_CPM_test_vns_port__INFO =  The CPM is about to test its VNS port {1} for availability. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_activating_vns_port__INFO =  The CPM VNS activity started on port {1}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_vns_process_serveon__FINEST =  VNS received a serveon request. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_assign_service_port__FINEST = Assigning Service Port. \
-  (Thread Name: {0}) Service PORT: {1} 
+  (Thread: {0}) Service PORT: {1} 
 
 UIMA_CPM_vns_shutdown__INFO = The CPM VNS received a request to stop. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_vns_stopped_serving__INFO = The CPM VNS activity stopped. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_launching_local_vns__INFO = The CPM VNS thread started. \
-  (Thread Name: {0}) VNS Port: {1} 
+  (Thread: {0}) VNS Port: {1} 
 
 UIMA_CPM_launching_local_vns_failed__SEVERE = VNS cannot start. \
-  (Thread Name: {0}) Failure Reason: {1} 
+  (Thread: {0}) Failure Reason: {1} 
 
 UIMA_CPM_service_active_on_port__FINEST = Service Active. \
-  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service PORT: {3}.
+  (Thread: {0}) Service Name: {1} Service Host: {2} Service PORT: {3}.
 
 UIMA_CPM_service_not_active_on_port__WARNING = The service {1} is not active. \
-  (Thread Name: {0}) Service Host: {2} Service Port: {3}.
+  (Thread: {0}) Service Host: {2} Service Port: {3}.
 
 UIMA_CPM_vns_redirect__FINEST = Redirecting Vinci <resolve> request to public VNS. \
-  (Thread Name: {0}) Public VNS HOST: {1} Public VNS HOST: {2}
+  (Thread: {0}) Public VNS HOST: {1} Public VNS HOST: {2}
 
 UIMA_CPM_unknown_vns_command__WARNING = Unknown VINCI command. \
-  (Thread Name: {0})  
+  (Thread: {0})  
 
 UIMA_CPM_assign_service_port_complete__FINEST = Completed Assigning Service Port. \
-  (Thread Name: {0}) Service PORT: {1} 
+  (Thread: {0}) Service PORT: {1} 
 
 UIMA_CPM_deactivating_vns_port__INFO =  VNS stopped. \
-  (Thread Name: {0})  
+  (Thread: {0})  
 
 UIMA_CPM_vns_port_not_available__SEVERE = No port can be acquired for the VNS service. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_test_local_port__INFO = The service port {1} is available on localhost. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_activating_service_on_port__FINEST = Activating Service Proxy. \
-  (Thread Name: {0}) Cas Processor Name: {1} Service Port Proxy {2} 
+  (Thread: {0}) CAS Processor Name: {1} Service Port Proxy {2} 
 
 UIMA_CPM_activating_service_on_port2__FINEST = Activating Service Proxy. \
-  (Thread Name: {0}) Cas Processor Name: {1} Index: {2} of {3}
+  (Thread: {0}) CAS Processor Name: {1} Index: {2} of {3}
 
 UIMA_CPM_service_exception__WARNING = Trying to reconnect the service proxy {2} of {3}. \
-  (Thread Name: {0}) CAS processor name: {1}
+  (Thread: {0}) CAS processor name: {1}
 
 UIMA_CPM_cp_checkpoint__FINEST = Check point for this cas processor. \
-  (Thread Name: {0}) Batch Size: {1} 
+  (Thread: {0}) Batch Size: {1} 
   
 UIMA_CPM_invalid_service_descriptor__SEVERE = {1} in {2} of the descriptor for this CAS processor is missing. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_killing_process__FINEST = Killing Process. \
-  (Thread Name: {0}) Process PID: {1} 
+  (Thread: {0}) Process PID: {1} 
   
 UIMA_CPM_show_sys_env__FINEST = System Environment Variable. \
-  (Thread Name: {0}) Env Key: {1} Env Value: {2}
+  (Thread: {0}) Env Key: {1} Env Value: {2}
   
 UIMA_CPM_set_service_timeout__FINEST = Setting Service Timeout. \
-  (Thread Name: {0}) Service Timeout: {1} 
+  (Thread: {0}) Service Timeout: {1} 
 
 UIMA_CPM_connect_to_service__FINEST = Connecting TAP to service. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
   
 UIMA_CPM_connected_to_service__FINEST = Connected TAP to service. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_testing_connection__FINEST = Testing Established Connection. \
-(Thread Name: {0}) Sleeping for 100ms and Getting Metadata
+(Thread: {0}) Sleeping for 100ms and Getting Metadata
 
 UIMA_CPM_service_pid__FINEST = Service PID. \
-(Thread Name: {0}) Service PID: {1}
+(Thread: {0}) Service PID: {1}
 
 UIMA_CPM_connection_closed__FINEST = Connection appears to be closed. \
-(Thread Name: {0}) Service PID: {1}
+(Thread: {0}) Service PID: {1}
 
 UIMA_CPM_connection_not_established__WARNING = No connection has been established Yet. Attempting to reconnect. Sleeping for 100ms first. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_connection_failed__WARNING = The system is unable to connect to the service host {1} through the service port {2}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_service_down__INFO = The service {1} is not running. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_use_default_metadata__FINEST = Defaulting to metadata in CPE Descriptor. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_no_metadata__FINEST = Container Metadata is Null. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_no_cp_configuration_in_metadata__FINEST = Container Metadata does not include casProcessor Configuration. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_service_down_onhost__INFO = The service hosted on {1} and port {2} is not running. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_show_memory_before_call__FINEST = Show Total Memory Available Before vinci Call (kb). \
-  (Thread Name: {0}) Available Memory : {1} Total Memory: {2}
+  (Thread: {0}) Available Memory : {1} Total Memory: {2}
 
 UIMA_CPM_show_memory__FINEST = Show Memory. \
-  (Thread Name: {0})  Total Memory: {1} Available Memory: {2}
+  (Thread: {0})  Total Memory: {1} Available Memory: {2}
 
 UIMA_CPM_show_total_memory__FINEST = Show Total Memory. \
-  (Thread Name: {0})  Total Memory: {1} 
+  (Thread: {0})  Total Memory: {1} 
 
-UIMA_CPM_checkout_cp_from_container__FINEST = Checking out Cas Processor from Container. \
-  (Thread Name: {0}) Container Name: {1}
+UIMA_CPM_checkout_cp_from_container__FINEST = Checking out CAS Processor from Container. \
+  (Thread: {0}) Container Name: {1}
 
-UIMA_CPM_checkedout_cp_from_container__FINEST = Checked out Cas Processor from Container. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
+UIMA_CPM_checkedout_cp_from_container__FINEST = Checked out CAS Processor from Container. \
+  (Thread: {0}) Container Name: {1} CAS Processor Class: {2}
 
 UIMA_CPM_is_container_paused__FINEST = Container Status. \
-  (Thread Name: {0}) Container Name: {1} Is Paused: {2}
+  (Thread: {0}) Container Name: {1} Is Paused: {2}
 
 UIMA_CPM_checkout_null_cp_from_container__SEVERE = The CAS processor in container {1} is NULL. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_container_not_ready__FINEST = Container Disabled. \
-  (Thread Name: {0}) Container Name: {1}
+  (Thread: {0}) Container Name: {1}
 
 UIMA_CPM_analysis_successfull__FINEST = Analysis has been successfull. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
 UIMA_CPM_end_of_batch__FINEST = Doing End-Of-Batch. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
 UIMA_CPM_release_cp__FINEST = Releasing CasProcessor to the Pool.. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
+  (Thread: {0}) Container Name: {1} CAS Processor: {2} Local Cache is NULL?: {3}
 
 UIMA_CPM_ok_release_cp__FINEST = Released CasProcessor to the Pool.. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2} Local Cache is NULL?: {3}
+  (Thread: {0}) Container Name: {1} CAS Processor: {2} Local Cache is NULL?: {3}
 
 UIMA_CPM_ok_released_cp__FINEST = Released CasProcessor to the Pool.. \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
   
 UIMA_CPM_container_paused__FINEST = Container has been paused. Released Cases. \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
 
 UIMA_CPM_pipeline_completed__FINEST = Processing Pipeline Pass Complete. Analysis Has Been Done. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_pipeline_exception__SEVERE = The container {1} returned the following error message: {2} \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_notify_listeners__FINEST = Notifying Listeners. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
-UIMA_CPM_done_notify_listeners__FINEST =  Done Notifying Listeners. \
-  (Thread Name: {0}) 
+UIMA_CPM_done_notify_listeners__FINEST = Done Notifying Listeners. \
+  (Thread: {0}) 
 
-UIMA_CPM_add_cas_to_queue__FINEST = Adding Results of Analysis to Queue. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+UIMA_CPM_add_cas_to_queue__FINEST = Adding results of analysis to queue. \
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
-UIMA_CPM_done_with_cas__FINEST = Cas in Queue. Nullifying References to CAS. \
-  (Thread Name: {0})  Current Memory: {1}
+UIMA_CPM_done_with_cas__FINEST = CAS in Queue. Nullifying References to CAS. \
+  (Thread: {0}) Current Memory: {1}
 
 UIMA_CPM_nullify_cas__FINEST = Nullifying References to CAS. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
-UIMA_CPM_show_local_cache__FINEST = Local Cas Cache. \
-  (Thread Name: {0})  Is Cas Cache Null: {1}
+UIMA_CPM_show_local_cache__FINEST = Local CAS Cache. \
+  (Thread: {0})  Is CAS Cache Null: {1}
 
 UIMA_CPM_end_of_batch_completed__FINEST = Done With End-Of-Batch. \
-  (Thread Name: {0}) Container Name: {1}
+  (Thread: {0}) Container Name: {1}
 
 UIMA_CPM_end_of_batch_exception__SEVERE = The method isEndOfBatch() in container {1} returned the following error message: {2} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_handle_exception__SEVERE = The container {1} is processing error message {3} generated by CAS processor {2}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_drop_cas__WARNING = The CAS is being dropped due to the CPM error handling configuration. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
 UIMA_CPM_container_paused_do_retry__FINEST = Container has been paused. Retrying the same document once the container is resumed. \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
 
 UIMA_CPM_pausing_container__FINEST = Pausing Container. \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
 
 UIMA_CPM_exception_on_pipeline_kill__WARNING = A request to stop a processing pipeline cannot be processed. The current container is {1}. \
-  (Thread Name: {0}) Reason: {2}
+  (Thread: {0}) Reason: {2}
 
 UIMA_CPM_exception_on_cpm_kill__WARNING = The CPM cannot be stopped by force. The current container is {1}. \
-  (Thread Name: {0}) Reason: {2}
+  (Thread: {0}) Reason: {2}
   
 UIMA_CPM_initialize_cas__FINEST = Initializing CAS. \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
 
 UIMA_CPM_casobjectlist_is_null__SEVERE = The method aCasObjectList[casIndex] returns null for container {1} in the CAS index {2}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_casObjects_class__FINEST = Cas Instance Class. \
-  (Thread Name: {0}) casObjects Class Name: {1} 
+UIMA_CPM_casObjects_class__FINEST = CAS Instance Class. \
+  (Thread: {0}) casObjects Class Name: {1} 
 
 
-UIMA_CPM_call_process__FINEST = Calling Cas Processor process(). \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+UIMA_CPM_call_process__FINEST = Calling CAS Processor process(). \
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
-UIMA_CPM_call_process_completed__FINEST = Done calling Cas Processor process(). \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+UIMA_CPM_call_process_completed__FINEST = Done calling CAS Processor process(). \
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
-UIMA_CPM_casobject_processor__FINEST = CasObject Cas Processor. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor: {2}
+UIMA_CPM_casobject_processor__FINEST = CasObject CAS Processor. \
+  (Thread: {0}) Container Name: {1} CAS Processor: {2}
 
-UIMA_CPM_get_cas_from_pool__FINEST = Retrieving Cas from cas pool. \
-  (Thread Name: {0}) Container Name: {1} 
+UIMA_CPM_get_cas_from_pool__FINEST = Retrieving CAS from cas pool. \
+  (Thread: {0}) Container Name: {1} 
 
 UIMA_CPM_call_processNext__FINEST = Calling processNext() . \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_call_processNext_done__FINEST = Done calling processNext() . \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_cas_data_processor__FINEST = CasProcessor is instanceof CasDataProcessor. \
-  (Thread Name: {0}) Container Name: {1} Cas Processor Class: {2}
+  (Thread: {0}) Container Name: {1} CAS Processor Class: {2}
 
 UIMA_CPM_dump_events__FINEST = Dumping Events. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_unexpected_artifact_type__SEVERE = The artifact type is invalid. The artifact class name is {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_expected_casdata__FINEST = Expected CasData. \
-  (Thread Name: {0}) Got: {1} Instead
+  (Thread: {0}) Got: {1} Instead
 
 UIMA_CPM_chunk_state_false_timeout__FINEST = Changing chunkState to false due to timeout. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_queue_empty__FINEST = Queue is empty. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_expected_chunk_sequenece__FINEST = Chunk Sequence. \
-  (Thread Name: {0}) Queue Name: {1} Expected Sequence: {2}
+  (Thread: {0}) (Queue: {1}) Expected Sequence: {2}
 
 UIMA_CPM_got_eof_token__FINEST = Got EOF Token. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_chunk_meta_is_null__FINEST = ChunkMetadata is NULL. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_sequence_timed_out__FINEST = Sequence Has Timed Out. \
-  (Thread Name: {0}) Queue Name: {1}  Returning CAS with sequence# {2}
+  (Thread: {0}) (Queue: {1})  Returning CAS with sequence# {2}
 
-UIMA_CPM_iscas__FINEST = Object from Queue is Cas. \
-  (Thread Name: {0}) Queue Name: {1} 
+UIMA_CPM_iscas__FINEST = Object from Queue is CAS. \
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_in_chunk_state__FINEST = In Chunk State. \
-  (Thread Name: {0}) Queue Name: {1} Expected Doc Id: {2} Got Doc Id: {3} Expected Sequence Id: {4} Got Sequence Id: {5}
+  (Thread: {0}) (Queue: {1}) Expected Doc Id: {2} Got Doc Id: {3} Expected Sequence Id: {4} Got Sequence Id: {5}
   
 UIMA_CPM_change_chunk_state__FINEST = Changing chunkState to false due to the fact the we just processed the last one in the sequence. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_not_in_chunk_state__FINEST = Not In Chunk State. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1}) 
 
-UIMA_CPM_begin_chunk_state__FINEST = Begining Chunk State. \
-  (Thread Name: {0}) Queue Name: {1} 
+UIMA_CPM_begin_chunk_state__FINEST = Beginning Chunk State. \
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_null_cas__FINEST = Not a CAS but NULL object. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_not_cas__FINEST = Unexpected Object Type. \
-  (Thread Name: {0}) Queue Name: {1} Expected CAS. Got {2} instead
+  (Thread: {0}) (Queue: {1}) Expected CAS. Got {2} instead
 
 UIMA_CPM_done_scanning_q__FINEST = Done With Scanning The Queue. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_expecte_seq_not_found__FINEST = Expected Sequence Not Found. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_show_queue_capacity__FINEST = Queue Capacity. \
-  (Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Current Queue Size: {3}
+  (Thread: {0}) (Queue: {1}) Queue Capacity: {2} Current Queue Size: {3}
 
 UIMA_CPM_wait_for_chunk__FINEST = No Expected Chunk Sequnce - Waiting Some More. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_timedout_waiting_for_chunk__FINEST = Timed Out While Waiting For Chunk Sequnce.. \
-  (Thread Name: {0}) Queue Name: {1} Doc ID: {2}  Skipping the document.
+  (Thread: {0}) (Queue: {1}) Doc ID: {2}  Skipping the document.
   
 UIMA_CPM_chunk_didnt_arrive__FINEST = Expected Chunk didnt arrive within a given window. \
-  (Thread Name: {0}) Queue Name: {1} Window (timeout): {2}  Changing chunkState to false.
+  (Thread: {0}) (Queue: {1}) Window (timeout): {2}  Changing chunkState to false.
   
 UIMA_CPM_return_chunk__FINEST = Returning from Queue. \
-  (Thread Name: {0}) Queue Name: {1} Queue Capacity: {2} Queue Current Size: {3}
+  (Thread: {0}) (Queue: {1}) Queue Capacity: {2} Queue Current Size: {3}
   
 UIMA_CPM_cas_not_valid__FINEST = CAS is NULL || CAS not CasData. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_timer_expired__FINEST = Timer Has Expired. \
-  (Thread Name: {0}) Doc ID: {1} Cache Size: {2}
+  (Thread: {0}) Doc ID: {1} Cache Size: {2}
 
 UIMA_CPM_expression__FINEST = Expression . \
-  (Thread Name: {0}) expr: {1}
+  (Thread: {0}) expr: {1}
 
 UIMA_CPM_java_timer__CONFIG = TimerFactory-instantiating JavaTimer. Higher precision Timer not specified. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_show_timer_class__CONFIG = Instantiating Timer Object. \
-  (Thread Name: {0}) Timer Class Name: {1}
+  (Thread: {0}) Timer Class Name: {1}
 
 UIMA_CPM_show_cas_fs_type__FINEST = CAS FEATURE STRUCTURE Type. \
-  (Thread Name: {0}) FS Type: {1}
+  (Thread: {0}) FS Type: {1}
 
 UIMA_CPM_show_cas_fs_value__FINEST = CAS FEATURE STRUCTURE Value. \
-  (Thread Name: {0}) FS Name: {1} FS Value: {2}
+  (Thread: {0}) FS Name: {1} FS Value: {2}
 
-UIMA_CPM_search_cas_by_value__FINEST= Search Cas by feature Name. \
-  (Thread Name: {0}) FS Name: {1} FS Type: {2}
+UIMA_CPM_search_cas_by_value__FINEST= Search CAS by feature Name. \
+  (Thread: {0}) FS Name: {1} FS Type: {2}
 
 UIMA_CPM_show_type_value__FINEST = Feature Structure Type and Value. \
-  (Thread Name: {0}) FS Type: {1} FS Value: {2}
+  (Thread: {0}) FS Type: {1} FS Value: {2}
 
 UIMA_CPM_cpm_init_complete__CONFIG = Collection Processsing managers initialization completed. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_method_ping__FINEST = Method Call. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_failed_component__FINEST = Component Failed. \
-  (Thread Name: {0}) Component: {1}
+  (Thread: {0}) Component: {1}
 
 UIMA_CPM_component_exception__FINEST = Failed Component Exception. \
-  (Thread Name: {0}) Exception: {1}
-
+  (Thread: {0}) Exception: {1}
 
 UIMA_CPM_show_total_time_in_cpm__FINEST = Total Time in CPM. \
-  (Thread Name: {0}) Time: {1}
-
-
-
-
-
-
-
-
+  (Thread: {0}) Time: {1}
 
 UIMA_CPM_artifact_null__SEVERE = The artifact is empty. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_exit_pp__FINEST = Exiting from CPM Processing Unit. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_pp_terminated__FINEST = Processing Pipeline Completed Processing CAS. \
-  (Thread Name: {0})
-
+  (Thread: {0})
 
 UIMA_CPM_drop_key__FINEST = Dropping Vinci Keys. \
-  (Thread Name: {0}) Key: {1}
+  (Thread: {0}) Key: {1}
 
 UIMA_CPM_analyze_bundle__FINEST = Analyzing CAS Bundle. \
-  (Thread Name: {0}) Bundle Size: {1}
+  (Thread: {0}) Bundle Size: {1}
 
 UIMA_CPM_dump_casdata__FINEST = CasData Key Dump. \
-  (Thread Name: {0}) Key: {1}
+  (Thread: {0}) Key: {1}
 
 UIMA_CPM_no_casdata__FINEST = CasData is Empty. \
-  (Thread Name: {0}) Skipping to the next...
+  (Thread: {0}) Skipping to the next...
   
 UIMA_CPM_send_casdata_to_service__FINEST = Sending request to service. \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
   
-UIMA_CPM_done_analyzing_bundle__FINEST = Done Analyzing Cas Data Bundle. Returning Results. \
-  (Thread Name: {0}) Bundle Size: {1}
+UIMA_CPM_done_analyzing_bundle__FINEST = Done Analyzing CAS Data Bundle. Returning Results. \
+  (Thread: {0}) Bundle Size: {1}
 
   
 UIMA_CPM_show_memory_after_call__FINEST = Show Total Memory After vinci Call (kb). \
-  (Thread Name: {0}) Available Memory : {1} Total Memory: {2}
+  (Thread: {0}) Available Memory : {1} Total Memory: {2}
 
 UIMA_CPM_received_response__FINEST = Returning Response. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_failed_service_request__WARNING = A service error occurred when processing a document. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_exception__FINER = Got Exception. \
-  (Thread Name: {0}) Message: {1}
+  (Thread: {0}) Message: {1}
   
 # https://issues.apache.org/jira/browse/UIMA-2440 
 UIMA_CPM_exception__WARNING = Got Exception. \
-  (Thread Name: {0}) Message: {1} 
+  (Thread: {0}) Message: {1} 
 
 UIMA_CPM_cr_exception__SEVERE = The CPM collection reader returned the following error message: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_cc_exception__SEVERE = The CAS consumer returned the following error message: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_service_connection_exception__SEVERE = The service returned the following error: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_service_exception__SEVERE = THE CPM service returned the following error message: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_waiting_for_service_shutdown__FINEST = Waiting for service to cleanup on shutdown. \
-  (Thread Name: {0}) Attempt: {1} of {2}
+  (Thread: {0}) Attempt: {1} of {2}
 
 UIMA_CPM_service_shutdown_completed__FINEST = Service Shutdown Completed. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_stopping_cp__FINEST = STOPPING CasProcessor. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_deploy_logger__FINEST = Deploying Logger. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_logpath_not_defined__FINEST = Container Log Path Not Defined. \
-  (Thread Name: {0}) Container Name: {1}
+  (Thread: {0}) Container Name: {1}
 
-UIMA_CPM_increment_cp_errors__FINEST = Incrementing Cas Processor Errors. \
-  (Thread Name: {0}) Container Name: {1}
+UIMA_CPM_increment_cp_errors__FINEST = Incrementing CAS Processor Errors. \
+  (Thread: {0}) Container Name: {1}
 
 UIMA_CPM_show_cp_error_count__FINEST = Show Current Error Count. \
-  (Thread Name: {0}) Container Name: {1} Error Count: {2} Message: {3}
+  (Thread: {0}) Container Name: {1} Error Count: {2} Message: {3}
 
 UIMA_CPM_abort_cpm__SEVERE = The CPM is terminating. The current component is {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_disable_cp__SEVERE = CAS processor {1} is disabled. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
-UIMA_CPM_show_cp_batch_size__FINEST = Cas Processor Batch Size. \
-  (Thread Name: {0}) Component Name: {1}  Batch Size: {2}
+UIMA_CPM_show_cp_batch_size__FINEST = CAS Processor Batch Size. \
+  (Thread: {0}) Component: {1}  Batch Size: {2}
 
-UIMA_CPM_show_cp_doc_count__FINEST = Cas Processor Processed Docs. \
-  (Thread Name: {0}) Component Name: {1}  So Far Processed: {2} Docs
+UIMA_CPM_show_cp_doc_count__FINEST = CAS Processor Processed Docs. \
+  (Thread: {0}) Component: {1}  So Far Processed: {2} Docs
 
 UIMA_CPM_cp_is_null__SEVERE = The CPM is in an unexpected state. The CAS processor is NULL. The component name is {1}. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_check_filter__FINEST = Checking CP Filter. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_filtering_disabled__FINEST = Filtering disabled (not defined). \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_filter_empty__FINEST = FilterList is empty. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
   
 UIMA_CPM_filter_enabled__FINEST = Filtering enabled. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_filter_enabled_no_right_operand__FINEST = No right Operand. Evaluating Filter Expression. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
-UIMA_CPM_pause_container__FINEST = Pausing Cas Processor Container. \
-  (Thread Name: {0}) Component Name: {1} 
+UIMA_CPM_pause_container__FINEST = Pausing CAS Processor Container. \
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_pause_cpe__FINEST = Pausing CPE. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_resume_cpe__FINEST = Resuming CPE after Pause. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_notify_engine__FINEST = Notifying Engine. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_pipeline_terminated__FINEST = Processing Pipeline Terminated. \
-  (Thread Name: {0}) Pipeline Thread Name: {1}
+  (Thread: {0}) Pipeline Thread Name: {1}
   
 UIMA_CPM_exception_while_consuming_cases__SEVERE = The following error message was returned While consuming CASes from the work queue during a forced shutdown: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_exception_in_single_threaded_cpm__SEVERE = The following error message was returned while running the single-threaded CPM: {1} \
-  (Thread Name: {0})  
+  (Thread: {0})  
 
 UIMA_CPM_starting_cpe__FINEST =Starting Collection Processing Engine. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_redefine_pool_size__CONFIG = CAS PoolSize exceeds hard limit(100). \
-  (Thread Name: {0})
+  (Thread: {0})
   
-UIMA_CPM_show_cas_pool_size__CONFIG = Cas Pool Size. \
-  (Thread Name: {0}) Current Size: {1}
+UIMA_CPM_show_cas_pool_size__CONFIG = CAS Pool Size. \
+  (Thread: {0}) Current Size: {1}
   
-UIMA_CPM_got_cas_from_pool__FINEST = Got Cas from Cas Pool. \
-  (Thread Name: {0})
+UIMA_CPM_got_cas_from_pool__FINEST = Got CAS from CAS Pool. \
+  (Thread: {0})
 
 
 UIMA_CPM_create_producer__CONFIG = Instantiating Producer. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_create_pus__CONFIG = Starting PUs. \
-  (Thread Name: {0}) Work Queue Size: {1}
+  (Thread: {0}) Work Queue Size: {1}
 
-UIMA_CPM_resuming_container__FINEST = Resuming Cas Processor Container. \
-  (Thread Name: {0}) Component Name: {1} 
+UIMA_CPM_resuming_container__FINEST = Resuming CAS Processor Container. \
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_checking_out_cp_from_pool__FINEST = Checking Out CasProcessor from Pool. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_checking_in_cp_to_pool__FINEST = Returning CasProcessor to Pool. \
-  (Thread Name: {0}) Total Size: {1} Free In Pool: {2}
+  (Thread: {0}) Total Size: {1} Free In Pool: {2}
 
 UIMA_CPM_checking_in_invalid_cp_to_pool__FINEST = An attempt is being made to return a CAS processor to a pool from which it was not checked out. \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_cp_not_in_pool__FINEST = Cas Processor Instance Not in mAllInstances. \
-  (Thread Name: {0})
+UIMA_CPM_cp_not_in_pool__FINEST = CAS Processor Instance Not in mAllInstances. \
+  (Thread: {0})
 
-UIMA_CPM_cp_already_checked_in__FINEST = Cas Processor Already Checked In to mFreeInstances. \
-  (Thread Name: {0})
+UIMA_CPM_cp_already_checked_in__FINEST = CAS Processor Already Checked In to mFreeInstances. \
+  (Thread: {0})
 
-UIMA_CPM_add_cp_to_pool__FINEST = Adding Cas Processor to Processor Instance Pool. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+UIMA_CPM_add_cp_to_pool__FINEST = Adding CAS Processor to Processor Instance Pool. \
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_reset_queue_size__FINEST = Resetting queue size to max process size. \
-  (Thread Name: {0}) New Queue Size: {1}
+  (Thread: {0}) New Queue Size: {1}
 
-UIMA_CPM_enqueue_cas_bundle__FINEST = Enqueing Cas Bundle. \
-  (Thread Name: {0}) Cas Bundle Size: {1}
+UIMA_CPM_enqueue_cas_bundle__FINEST = Enqueing CAS Bundle. \
+  (Thread: {0}) CAS Bundle Size: {1}
 
 UIMA_CPM_show_cr_progress__FINEST = Collection Reader Progress. \
-  (Thread Name: {0}) CR Processed: {1} Documents So Far
+  (Thread: {0}) CR Processed: {1} Documents So Far
 
 UIMA_CPM_cr_fetch_new_cas__FINEST = Collection Reader Fetch New CAS instance from Pool. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_cr_check_cas_for_null__FINEST = Collection Reader Retrieved New CAS Instance From Pool. \
-  (Thread Name: {0}) Is Cas NULL: {1}
+  (Thread: {0}) Is CAS NULL: {1}
   
 UIMA_CPM_in_shutdown_state__FINEST = CPM is in shutdown state.Returning null from getNext(). \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_got_new_cas__FINEST = Collection Reader Fetched New CAS instance from Pool. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_call_cas_reset__FINEST = Calling Reset on CAS. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_call_cr_next__FINEST = Calling CR.getNext(). \
-  (Thread Name: {0}) CAS Type: {1}
+  (Thread: {0}) CAS Type: {1}
 
 UIMA_CPM_call_cr_next_finished__FINEST = Done Calling CR.getNext(). \
-  (Thread Name: {0}) CAS Type: {1}
+  (Thread: {0}) CAS Type: {1}
 
 UIMA_CPM_return_cases_from_cr__FINEST = Returning CAS from CollectionReader. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 
-UIMA_CPM_show_cp_pool_size__FINEST = Cas Processor Pool. \
-  (Thread Name: {0}) Total Size: {1} Free In Pool: {2}
+UIMA_CPM_show_cp_pool_size__FINEST = CAS Processor Pool. \
+  (Thread: {0}) Total Size: {1} Free In Pool: {2}
   
 UIMA_CPM_cp_pool_empty__WARNING = The CAS processor pool is empty. \
-  (Thread Name: {0}) Total size: {1} Free in pool: {2}
+  (Thread: {0}) Total size: {1} Free in pool: {2}
 
 UIMA_CPM_cpm_not_running__WARNING = The CPM is not running. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_start_pp__FINEST = Starting Processing Pipeline. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
   
 UIMA_CPM_dequeue_artifact__FINEST = Dequeueing next artifact from queue. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_maxwait_for_artifact__FINEST = Max Wait for artifact. \
-  (Thread Name: {0}) Wait Time: {1}
+  (Thread: {0}) Wait Time: {1}
 
 
 UIMA_CPM_cr_done_producing__FINEST = Artifact Producer Done Producing. \
-  (Thread Name: {0}). Adding EOF Marker
+  (Thread: {0}). Adding EOF Marker
 
 UIMA_CPM_eof_marker_enqueued__FINEST = Placed EOF Marker in Work Queue. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_placed_eof_in_queue__FINEST = Adding EOF Marker in Queue. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_done_placed_eof_in_queue__FINEST = Done Adding EOF Marker in Queue. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_done_notifying_queue__FINEST = Done Notifying Queue. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_exception_adding_eof__SEVERE = The following error message was returned while adding the end-of-file token to the output queue: {1} \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_cc_completed__FINEST = CasConsumer Thread is Done. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_pus_completed__FINEST = All Processing Pipelined completed. Unloading Output Queue. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_cleaning_up_pus__FINEST = All PUs completed. Terminating Annotators and Cleaning Up. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_engine_stopped__FINEST = Engine Stopped. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_destroy_thread_group__FINEST = DESTROYING THREAD GROUP. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_show_thread__FINEST = Thread Info. \
-  (Thread Name: {0}) Thread Index: {1} CPE Thread Name: {2}
+  (Thread: {0}) Thread Index: {1} CPE Thread Name: {2}
 
 UIMA_CPM_stop_containers__FINEST = Stopping Containers. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_show_container_time__FINEST = Container Processing Time. \
-  (Thread Name: {0}) Container Name: {1} Total Time in Container: {2}
+  (Thread: {0}) Container Name: {1} Total Time in Container: {2}
 
 UIMA_CPM_stop_container__FINEST = Stopping Container. \
-  (Thread Name: {0}) Container Name: {1}
+  (Thread: {0}) Container Name: {1}
 
 UIMA_CPM_release_tcas__FINEST = TCAS list member is null. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_call_get_cas__FINEST = Calling casPool.getCas(0). \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_call_get_cas_returns__FINEST = Done Calling casPool.getCas(0). \
-  (Thread Name: {0}) Is CAS NULL: {1}
+  (Thread: {0}) Is CAS NULL: {1}
   
 UIMA_CPM_use_custom_timer__FINEST = Using Custom Timer to Measure Performance. \
-  (Thread Name: {0}) Timer class: {1}
+  (Thread: {0}) Timer class: {1}
   
 UIMA_CPM_use_default_timer__FINEST = Using Default Timer to Measure Performance. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_unhandled_error__SEVERE = The CPM thread group caught the following unhandled error: {1} \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_checkpoint_target_not_defined__FINEST = DebugControlThread- Target To Checkpoint not defined. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_invalid_cpm_instance__FINEST = DebugControlThread -CPM instance not valid - Null. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_thread_terminating__FINEST = Thread Terminating. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_disabling_key__FINEST = Disabling Key. \
-  (Thread Name: {0}) Key: {1} Value: {2}
+  (Thread: {0}) Key: {1} Value: {2}
 
 UIMA_CPM_enabling_key__FINEST =  Enabling Key. \
-  (Thread Name: {0}) Key: {1} Value: {2}
+  (Thread: {0}) Key: {1} Value: {2}
   
 UIMA_CPM_show_access_control_file__FINEST = Control File. \
-  (Thread Name: {0}) File Name: {1}
+  (Thread: {0}) File Name: {1}
   
 UIMA_CPM_access_control_file_not_found__FINEST = Control File Not Found. \
-  (Thread Name: {0}) File Name: {1}
+  (Thread: {0}) File Name: {1}
   
 UIMA_CPM_initialize_pipeline__FINEST = Initializing Processing Unit. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
   
 UIMA_CPM_timer_class__FINEST = Timer class for this run. \
-  (Thread Name: {0}) Timer Class Name: {1}
+  (Thread: {0}) Timer Class Name: {1}
   
 UIMA_CPM_disabled_cp__FINEST = Request to disable CasProcessor. \
-  (Thread Name: {0}) Cas Processor Name: {1} has been disabled.
+  (Thread: {0}) CAS Processor Name: {1} has been disabled.
   
 UIMA_CPM_enabled_cp__FINEST = Enabling CasProcessor. \
-  (Thread Name: {0}) Cas Processor Name: {1} has been enabled.
+  (Thread: {0}) CAS Processor Name: {1} has been enabled.
   
 UIMA_CPM_start_analysis__FINEST = Starting Analysis. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_invalid_cas_reference__SEVERE = An invalid CAS reference (CAS=NULL) was passed. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_entering_pipeline__FINEST = Entering Pipeline. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_retrieve_container__FINEST = Getting Next Container. \
-  (Thread Name: {0}) Container Index: {1}
+  (Thread: {0}) Container Index: {1}
   
   
 UIMA_CPM_pausing_cr__FINEST = Pausing ArtifactProducer Thread . \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_pausing_pp__FINEST = Pausing Processing Pipeline . \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_resuming_pp__FINEST = Resuming Processing Pipeline . \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_resume_cr__FINEST = Resuming ArtifactProducer Thread . \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_call_hasnext__FINEST = Calling CR.hasNext(). \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_get_cas_from_cr__FINEST = Getting Next Cas from CR. \
-  (Thread Name: {0})
+UIMA_CPM_get_cas_from_cr__FINEST = Getting Next CAS from CR. \
+  (Thread: {0})
 
 UIMA_CPM_place_cas_in_queue__FINEST = Enqueuing CAS Bundle onto work queue. \
-  (Thread Name: {0}) CAS bundle size: {1}
+  (Thread: {0}) CAS bundle size: {1}
   
 UIMA_CPM_placed_cas_in_queue__FINEST = Enqueued CAS Bundle onto work queue. \
-  (Thread Name: {0}) CAS bundle size: {1}
+  (Thread: {0}) CAS bundle size: {1}
 
 UIMA_CPM_terminate_cr_thread__FINEST = Terminating CollectionReader Thread. \
-  (Thread Name: {0}). CPM is in shutdown state.
+  (Thread: {0}). CPM is in shutdown state.
 
 UIMA_CPM_processed_all__FINEST = CollectionReader has no more entities to process. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_end_of_processing__FINEST = End of Processing Reached. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_show_cpm_running_status__FINEST = Show CPM Running State. \
-  (Thread Name: {0}) CPM is running: {1}
+  (Thread: {0}) CPM is running: {1}
 
 UIMA_CPM_enqueue_eof_token__FINEST = Placing EOF Token on the Work Queue. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_done_enqueue_eof_token__FINEST = Done Placing EOF Token on the Work Queue. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_got_eof_token__FINEST = EOF Token Found Terminating ProcessingUint. \
-  (Thread Name: {0})
-
-
-
-
+  (Thread: {0})
 
 UIMA_CPM_entering_queue__FINEST = Entering enqueue(). \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_queue_full__FINEST = Queue is full. Waiting ... \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_adding_cas_to_queue__FINEST = adding CAS to QUEUE. \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
-UIMA_CPM_cas_in_queue__FINEST = Cas added to queue. \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+UIMA_CPM_cas_in_queue__FINEST = CAS added to queue. \
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_enter_dequeue__FINEST = Entering dequeue(). \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
-UIMA_CPM_cas_dequeued__FINEST = Cas bundle dequeued from queue. \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+UIMA_CPM_cas_dequeued__FINEST = CAS bundle dequeued from queue. \
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_no_cas_dequeued__FINEST = No data in the queue. \
-  (Thread Name: {0}) Queue Name: {1} 
+  (Thread: {0}) (Queue: {1}) 
 
 UIMA_CPM_return_from_dequeue__FINEST = Returning from dequeue. \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_queue_empty__FINEST = Queue Empty. \
-  (Thread Name: {0}) Queue Name: {1} Will wait until notified.
+  (Thread: {0}) (Queue: {1}) Will wait until notified.
 
 UIMA_CPM_queue_notified__FINEST = Queue notified. New data available. \
-  (Thread Name: {0}) Queue Name: {1} Current Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Current Queue Size: {2}
 
 UIMA_CPM_add_cas_to_checkedout_list__FINEST = Added CAS to the Checked Out List. \
-  (Thread Name: {0}) Current List Size: {1}
+  (Thread: {0}) Current List Size: {1}
 
 UIMA_CPM_invalid_checkin__WARNING = An attempt is being made to return a CAS to a pool from which it was not checked out. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_removed_from_checkedout_list__FINEST = Removed CAS from the Checked Out List. \
-  (Thread Name: {0}) Current List Size: {1}
+  (Thread: {0}) Current List Size: {1}
 
-UIMA_CPM_return_cas_to_pool__FINEST = Done Returning Cas Back To Pool. \
-  (Thread Name: {0}) Current List Size: {1}
+UIMA_CPM_return_cas_to_pool__FINEST = Done Returning CAS Back To Pool. \
+  (Thread: {0}) Current List Size: {1}
 
 UIMA_CPM_single_threaded_mode__CONFIG = Running CPE in single-threaded mode. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_multi_threaded_mode__CONFIG = Running CPE in multi-threaded mode. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_show_cr_state__INFO = The collection reader thread state is: {1} \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_show_pu_state__INFO = The CPM processing unit is {1} and processing state {2}. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_show_cc_state__INFO = The CAS consumer thread state is {1}. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_killing_cpm__INFO = The application stopped the CPM. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_killing_cpm__WARNING = The application stopped the CPM. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_stop_cpm__WARNING = Processing the request to stop the CPM. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_asynch_stop_cpm__WARNING = Processing an asynchronous request to stop the CPM. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_cpm_stopped__FINEST = Stopped CPM Engine. Notifying Listeners. \
-  (Thread Name: {0}) Killed: {1}
+  (Thread: {0}) Killed: {1}
 
 UIMA_CPM_terminate_pipelines__INFO = The CPM engine is stopping. An end-of-file token is added to the worker queue. \
-  (Thread Name: {0}) Forced stop: {1}
+  (Thread: {0}) Forced stop: {1}
 
 UIMA_CPM_already_stopped__FINEST = Engine Already stopped. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_consuming_queue__FINEST = Consuming queue... \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_wait_consuming_queue__FINEST = Waiting for PU to consume queue. \
-  (Thread Name: {0}) Queue Name: {1} Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) Queue Size: {2}
 
 UIMA_CPM_done_consuming_queue__FINEST = Done consuming queues. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_stop_processors__FINEST = Stopping CasProcessors. \
-  (Thread Name: {0}) PU index: {1}
+  (Thread: {0}) PU index: {1}
 
 UIMA_CPM_exception_during_cp_stop__WARNING = The CAS processors in container {1} cannot be stopped. \
-  (Thread Name: {0}) Reason: {2}
+  (Thread: {0}) Reason: {2}
 
 UIMA_CPM_stop_ccs__FINEST = Terminating CasConsumers and Cleaning Up . \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_stop_cpm__FINEST = Stopping CPM. Placing EOF Token on the Worker Queue. \
-  (Thread Name: {0}) Killed: {1}
+  (Thread: {0}) Killed: {1}
 
 UIMA_CPM_invalid_processor_configuration__SEVERE = The CAS processor configuration cannot be found in the CPE factory. \
-  (Thread Name: {0}) Lookup Key: {1}
+  (Thread: {0}) Lookup Key: {1}
 
-UIMA_CPM_add_consumer_to_list__CONFIG = Adding New Consumer to Existing Consumer List. \
-  (Thread Name: {0}) Consumer Name: {1}
+UIMA_CPM_add_consumer_to_list__CONFIG = Adding new consumer to Existing Consumer List. \
+  (Thread: {0}) Consumer Name: {1}
 
-UIMA_CPM_add_consumer_to_new_list__CONFIG = Adding New Consumer to New Consumer List. \
-  (Thread Name: {0}) Consumer Name: {1}
+UIMA_CPM_add_consumer_to_new_list__CONFIG = Adding new consumer to New Consumer List. \
+  (Thread: {0}) Consumer Name: {1}
 
-UIMA_CPM_add_pcp_to_existing_list__CONFIG = Adding New Parallelizable Cas Processor to existing List. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+UIMA_CPM_add_pcp_to_existing_list__CONFIG = Adding new parallelizable CAS Processor to existing List. \
+  (Thread: {0}) CAS Processor Name: {1}
 
-UIMA_CPM_add_pcp_to_new_list__CONFIG = Adding New Parallelizable Cas Processor to New Processor List. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+UIMA_CPM_add_pcp_to_new_list__CONFIG = Adding new parallelizable CAS Processor to New Processor List. \
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_diabled_cp__FINEST = Request to disable CasProcessor succeeded. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
-UIMA_CPM_enabled_cp__FINEST = Re-enabled Cas Proceesor. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+UIMA_CPM_enabled_cp__FINEST = Re-enabled CAS Proceesor. \
+  (Thread: {0}) CAS Processor Name: {1}
 
-UIMA_CPM_invoke_cp_process__FINEST = Invoking process on Cas Processor. \
-  (Thread Name: {0}) Container: {1} Cas Processor Name: {2}
+UIMA_CPM_invoke_cp_process__FINEST = Invoking process on CAS Processor. \
+  (Thread: {0}) Container: {1} CAS Processor Name: {2}
 
 UIMA_CPM_casobject_class__FINEST = CasObject Class. \
-  (Thread Name: {0}) Container: {1} CasObject Class Name: {2}
+  (Thread: {0}) Container: {1} CasObject Class Name: {2}
 
 UIMA_CPM_expected_casdata_class__FINEST = Expected CasData Instance. \
-  (Thread Name: {0}) Container: {1} Got: {2} Instead.
-
-
-
-
-
-
+  (Thread: {0}) Container: {1} Got: {2} Instead.
 
 UIMA_CPM_exception_when_checkpointing__FINEST = Exception While Generating Checkpoint. \
-  (Thread Name: {0}) Message: {1}
+  (Thread: {0}) Message: {1}
 
 
 UIMA_CPM_checkpoint_with_synchpoint__FINEST = checkpointing with SynchPoint. \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_checkpoint_with_pt__FINEST = checkpointing with Process Trace. \
-  (Thread Name: {0})
+UIMA_CPM_checkpoint_with_pt__FINEST = checkpointing with process trace. \
+  (Thread: {0})
 
 
 UIMA_CPM_restoring_from_checkpoint__FINEST = Restoring from Checkpoint. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_synchpoint_from_file__FINEST = Retrieving SynchPoint from File. \
-  (Thread Name: {0}) Synchpoint File: {1}
+  (Thread: {0}) SynchPoint file: {1}
 
 UIMA_CPM_sleep__FINEST = Sleeping. \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_wakeup__FINEST = Wakeing up. \
-  (Thread Name: {0})
+UIMA_CPM_wakeup__FINEST = Waking up. \
+  (Thread: {0})
 
 UIMA_CPM_checkpoint__FINEST = Checkpoint. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_stop_checkpoint_thread__INFO = The CPM checkpoint thread stopped. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_paused__FINEST = CPM Paused. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_resumed__FINEST = CPM Resumed. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_stopped__FINEST = CPM Stopped. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_filter_enabled_left_part__FINEST = No right Operand. LeftPart Exists. \
-  (Thread Name: {0}) Component Name: {1} Left Part: {2} Has Left Part? : {3}
+  (Thread: {0}) Component: {1} Left Part: {2} Has Left Part? : {3}
 
 
 UIMA_CPM_filter_false__FINEST = Filter evaluates false. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_container_paused__FINEST = Container in Pause State. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_resuming_container__FINEST = Resuming Container After Sleep. \
-  (Thread Name: {0}) Component Name: {1} Slept for: {2}
+  (Thread: {0}) Component: {1} Slept for: {2}
 
-UIMA_CPM_wait_no_processor__FINEST = Waiting for valid (non-null) Cas Processor. \
-  (Thread Name: {0}) Component Name: {1} 
+UIMA_CPM_wait_no_processor__FINEST = Waiting for valid (non-null) CAS Processor. \
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_destroy_processor__FINEST = Destroying CasProcessor Instance. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
   
 UIMA_CPM_failed_waiting_for_processor__SEVERE = An error occurred while waiting for the CAS processor {1}. \
-  (Thread Name: {0}) Reason: {2}
+  (Thread: {0}) Reason: {2}
 
-UIMA_CPM_show_cp_action_on_error__FINEST = Cas Processor Action On Error. \
-  (Thread Name: {0}) Component Name: {1} Action: {2}
+UIMA_CPM_show_cp_action_on_error__FINEST = CAS Processor Action On Error. \
+  (Thread: {0}) Component: {1} Action: {2}
   
 UIMA_CPM_action_on_error_not_defined__SEVERE = The ''action'' attribute of the <errorRateThreshold> element in component {1} is not defined. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_show_cp_proxy_pool_size__FINEST = Proxy Pool Size. \
-  (Thread Name: {0}) Component Name: {1} Pool Size: {2}
+  (Thread: {0}) Component: {1} Pool Size: {2}
 
 UIMA_CPM_cp_configuration_not_defined__SEVERE = The configuration of CAS processor {1} is not defined correctly in the CPE descriptor. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_no_proxies__SEVERE = The CAS processor proxies for component {1} cannot be acquired. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_cp_deployment_mode_not_defined__SEVERE = The CAS processor deployment mode [integrated|local|remote] in component {1} cannot be determined. Check the CPE descriptor. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_cp_failed_to_start__SEVERE = The CPM cannot be started. \
-  (Thread Name: {0}) Reason: {1}
+  (Thread: {0}) Reason: {1}
   
 UIMA_CPM_reduce_pipelines__CONFIG = Reducing Number of Processing Pipelines due to insufficient number of exclusive services. \
-  (Thread Name: {0}) Component Name: {1}
+  (Thread: {0}) Component: {1}
 
 UIMA_CPM_initialize_pipeline__FINEST = Intializing Processing Pipeline. \
-  (Thread Name: {0}) Pipeline Index: {1}
+  (Thread: {0}) Pipeline Index: {1}
   
 UIMA_CPM_pipeline_impl_class__FINEST = Processing Pipeline Class. \
-  (Thread Name: {0}) Pipeline Impl Class: {1}
+  (Thread: {0}) Pipeline Impl Class: {1}
   
 UIMA_CPM_started_pipelines__FINEST = Started All Processing Pipelines. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_join_threads__FINEST = Joining Threads. \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_cr_thread_completed__FINEST = Collection Reader Thread Completed. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_join_pu__FINEST = Joining Processing Pipeline. \
-  (Thread Name: {0}) Pipeline: {1} Index: {2}
+  (Thread: {0}) Pipeline: {1} Index: {2}
   
 UIMA_CPM_join_pu_complete__FINEST = Processing Pipeline Thread Completed. \
-  (Thread Name: {0}) Pipeline: {1} Index: {2}
+  (Thread: {0}) Pipeline: {1} Index: {2}
 
-UIMA_CPM_join_cc__FINEST = Joining Cas Consumer Thread. \
-  (Thread Name: {0})
+UIMA_CPM_join_cc__FINEST = Joining CAS Consumer Thread. \
+  (Thread: {0})
 
 UIMA_CPM_join_cc_completed__FINEST = CasConsumer Thread completed. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_exception_converting_CAS__WARNING = The CAS cannot be converted. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_release_cas_from_cache__FINEST = Releasing CAS from local Cache. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_release_cas_from_cache_done__FINEST = Done releasing CAS from local Cache. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_exception_releasing_cas__SEVERE = The Common Analysis Structures in container {1} cannot be released. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
   
 UIMA_CPM_releasing_cases__FINEST = Releasing CASes . \
-  (Thread Name: {0}) Container Name: {1} Release CAS: {2} Last Cas Processor: {3}
+  (Thread: {0}) Container Name: {1} Release CAS: {2} Last CAS Processor: {3}
   
 UIMA_CPM_done_releasing_cases__FINEST = Done releasing CASes . \
-  (Thread Name: {0}) Container Name: {1} 
+  (Thread: {0}) Container Name: {1} 
 
 
 UIMA_CPM_max_restart_reached__FINEST = Max restart Count reached. \
-  (Thread Name: {0}) Component Name: {1} Max Threshold: {2}
+  (Thread: {0}) Component: {1} Max Threshold: {2}
 
 UIMA_CPM_terminate_due_to_action__SEVERE = The CPM is stopped, because the current CAS processor generated too many errors. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
-UIMA_CPM_disable_due_to_action__FINEST = Disabling Cas Processor due to configured action. \
-  (Thread Name: {0}) Component Name: {1} 
+UIMA_CPM_disable_due_to_action__FINEST = Disabling CAS Processor due to configured action. \
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_kill_pipeline__FINEST = Killing Pipeline Thread. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
-UIMA_CPM_kill_cp__FINEST = Killing Cas Processor . \
-  (Thread Name: {0}) Cas Processor Name: {1} 
+UIMA_CPM_kill_cp__FINEST = Killing CAS Processor . \
+  (Thread: {0}) CAS Processor Name: {1} 
 
 UIMA_CPM_container_status__FINEST = Container Status. \
-  (Thread Name: {0}) Container: {1} Status: {2} 
+  (Thread: {0}) Container: {1} Status: {2} 
 
-UIMA_CPM_undeploy_cp_instances__FINEST = Undeploy Cas Processors. \
-  (Thread Name: {0}) Container: {1} Deployer Class Name: {2}
+UIMA_CPM_undeploy_cp_instances__FINEST = Undeploy CAS Processors. \
+  (Thread: {0}) Container: {1} Deployer Class Name: {2}
 
 
 UIMA_CPM_skip_CAS__FINEST = Skipping CAS and moving on based on action associated with this annotator. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_force_reconnect__FINEST = Throwing ServiceConnectionException to force reconnect. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_other_exception__FINEST = Other Exception. \
-  (Thread Name: {0}) Component Name: {1} Exception Name: {2}
+  (Thread: {0}) Component: {1} Exception Name: {2}
 
 UIMA_CPM_no_resource_exception__FINEST = Not ResourceProcessException. \
-  (Thread Name: {0}) Component Name: {1} Exception: {2}
+  (Thread: {0}) Component: {1} Exception: {2}
 
 UIMA_CPM_abort_exceeded_error_threshold__SEVERE = The CPM stopped because the configured error threshold {2} was exceeded. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
 UIMA_CPM_disable_exceeded_error_threshold__SEVERE = The CAS processor is disabled because the configured error threshold {2} was exceeded. \
-  (Thread Name: {0}) Component Name: {1} 
+  (Thread: {0}) Component: {1} 
 
-UIMA_CPM_skipping_cas__FINEST = Skipping Cas. \
-  (Thread Name: {0}) Component Name: {1}
+UIMA_CPM_skipping_cas__FINEST = Skipping CAS. \
+  (Thread: {0}) Component: {1}
 
 
 UIMA_CPM_log_docid__FINEST = Logging DocID. \
-  (Thread Name: {0}) Container Name: {1} Doc ID: {2} 
+  (Thread: {0}) Container: {1} Doc ID: {2} 
 
-UIMA_CPM_max_restart_action__FINEST = Cas Processor max restart action. \
-  (Thread Name: {0}) Cas Processor Name: {1} action:{2}
+UIMA_CPM_max_restart_action__FINEST = CAS Processor max restart action. \
+  (Thread: {0}) CAS Processor: {1} action:{2}
 
 UIMA_CPM_show_docs_to_process__CONFIG = Number of Documents to Process. \
-  (Thread Name: {0}) Doc Count: {1}
+  (Thread: {0}) Doc Count: {1}
 
 UIMA_CPM_show_start_doc_id__FINEST = Begin Processing with Entity Id. \
-  (Thread Name: {0}) Doc ID: {1}
+  (Thread: {0}) Doc ID: {1}
 
 UIMA_CPM_dequeued_artifact__FINEST = Dequeued Next Artifact from Queue. \
-  (Thread Name: {0}) Queue Name: {1}
+  (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_show_cp_filter__FINEST = CP Filter Expression. \
-  (Thread Name: {0}) Cas Processor Name: {1} Filter Expression: {2}
+  (Thread: {0}) CAS Processor Name: {1} Filter Expression: {2}
 
 UIMA_CPM_show_cp_deploy_params__FINEST = Show CP Deploy Param. \
-  (Thread Name: {0}) Cas Processor Name: {1} Deploy Param Name:{2} Deploy Param Value:{3}
+  (Thread: {0}) CAS Processor Name: {1} Deploy Param Name:{2} Deploy Param Value:{3}
  
 UIMA_CPM_config_non_java_service__FINEST = Configuring Non-Java Application. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_cp_failure_sample_size__FINEST = failureThresholdSample configuration. \
-  (Thread Name: {0}) Cas Processor Name: {1} error Sample Size: {2}
+  (Thread: {0}) CAS Processor Name: {1} error Sample Size: {2}
 
 UIMA_CPM_config_java_service__FINEST = Configuring Java Application. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
 UIMA_CPM_service_rejected_requested__WARNING = The service {1} rejected an invalid request. Reason code: {2} \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_request_metadata__FINEST = Requesting Metadata. \
-  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_return_meta__FINEST = Returning Metadata from Service. \
-  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_done_parsing_meta__FINEST = Done Parsing Metadata. \
-  (Thread Name: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
+  (Thread: {0}) Service Name: {1} Service Host: {2} Service Port: {3}
 
 UIMA_CPM_send_batch_complete__FINEST = Sending Batch Complete to Service. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}
+  (Thread: {0}) Service Host: {1} Service Port: {2} Query: {3}
   
 UIMA_CPM_send_collection_complete__FINEST = Sending Collection Complete to Service. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} Query: {3}  
+  (Thread: {0}) Service Host: {1} Service Port: {2} Query: {3}  
 
 UIMA_CPM_time_spent_serializing_xcas__FINEST = Total Time Spent Serializing to XCAS. \
-  (Thread Name: {0}) Time: {1}   
+  (Thread: {0}) Time: {1}   
 
 UIMA_CPM_time_spent_deserializing_xcas__FINEST = Total Time Spent Deserializing to XCAS. \
-  (Thread Name: {0}) Time: {1}   
+  (Thread: {0}) Time: {1}   
   
 UIMA_CPM_time_spent_in_transit__FINEST = Total Round-Trip Time (Send-Analyze-Receive). \
-  (Thread Name: {0}) Time: {1}   
+  (Thread: {0}) Time: {1}   
 
 UIMA_CPM_sending_process_req__FINEST = Sending Process Request to Service. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} Timeout: {3}
+  (Thread: {0}) Service Host: {1} Service Port: {2} Timeout: {3}
 
 UIMA_CPM_stopping_service__INFO = The service application stopped. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2} CMD: {3}
+  (Thread: {0}) Service Host: {1} Service Port: {2} CMD: {3}
 
 UIMA_CPM_vns_not_provided__SEVERE = The VNS_HOST or VNS_PORT are not initialized. \
-(Thread Name: {0})
+(Thread: {0})
 
 UIMA_CPM_locating_service__FINEST = Resolving service. \
-(Thread Name: {0}) Service Name: {1} VNS_HOST: {2} VNS_PORT: {3}
+(Thread: {0}) Service Name: {1} VNS_HOST: {2} VNS_PORT: {3}
 
 
 UIMA_CPM_connection_validated__FINEST = Connection to service is working. Received Metadata. \
-  (Thread Name: {0}) Service Host: {1} Service Port: {2}
+  (Thread: {0}) Service Host: {1} Service Port: {2}
 
 UIMA_CPM_killing_process_failed__WARNING = A process with PID {1} cannot be stopped. \
-  (Thread Name: {0}) 
+  (Thread: {0}) 
 
 UIMA_CPM_deploying_cp__FINEST = Deploying CasProcessor. \
-  (Thread Name: {0}) CP name: {1} 
+  (Thread: {0}) CP name: {1} 
 
-UIMA_CPM_producing_cas_consumer__FINEST = Producing Cas Consumer. \
-  (Thread Name: {0}) 
+UIMA_CPM_producing_cas_consumer__FINEST = Producing CAS Consumer. \
+  (Thread: {0}) 
 
-UIMA_CPM_producing_cas_data_consumer__FINEST = Producing Cas Data Consumer. \
-  (Thread Name: {0}) 
+UIMA_CPM_producing_cas_data_consumer__FINEST = Producing CAS Data Consumer. \
+  (Thread: {0}) 
 
 UIMA_CPM_add_cp__CONFIG = Adding CasProcessor. \
-  (Thread Name: {0}) Cas Processor Name: {1}
+  (Thread: {0}) CAS Processor Name: {1}
 
-UIMA_CPM_add_cp_with_index__FINEST = Adding New Cas Processor. \
-  (Thread Name: {0}) CP Name: {1} Appending to list. List length: {2}
+UIMA_CPM_add_cp_with_index__FINEST = Adding New CAS Processor. \
+  (Thread: {0}) CP Name: {1} Appending to list. List length: {2}
 
-UIMA_CPM_show_cp_deployment__FINEST = Cas Processor Deployment Mode. \
-  (Thread Name: {0}) CP Name: {1} Deployment Mode: {2}
+UIMA_CPM_show_cp_deployment__FINEST = CAS Processor Deployment Mode. \
+  (Thread: {0}) CP Name: {1} Deployment Mode: {2}
 
 UIMA_CPM_add_cp_from_list__FINEST = Adding New CasProcessors from the List. \
-  (Thread Name: {0}) CP Name: {1}
+  (Thread: {0}) CP Name: {1}
 
 UIMA_CPM_create_new_cp_from_list__FINEST = Creating New CasProcessors from the List. \
-  (Thread Name: {0}) CP Name: {1}
+  (Thread: {0}) CP Name: {1}
 
 UIMA_CPM_show_os__FINEST = Operating System. \
-  (Thread Name: {0}) OS: {1}
+  (Thread: {0}) OS: {1}
 
 UIMA_CPM_show_cmd_classpath__FINEST = Split classpath. \
-  (Thread Name: {0}) Current Classpath: {1}
+  (Thread: {0}) Current Classpath: {1}
 
 UIMA_CPM_deploying_cp__FINEST = Redeploying CasProcessor. \
-  (Thread Name: {0}) CP name: {1} 
+  (Thread: {0}) CP name: {1} 
 
 UIMA_CPM_deploying_new_cp__CONFIG = Deploying CasProcessor. \
-  (Thread Name: {0}) CP name: {1} 
+  (Thread: {0}) CP name: {1} 
 
 UIMA_CPM_cp_deployment__FINEST =  CP Deployment. \
-  (Thread Name: {0}) Deployment Mode: {1} 
+  (Thread: {0}) Deployment Mode: {1} 
 
 UIMA_CPM_show_cmd_arg__FINEST = Current Arg. \
-  (Thread Name: {0}) Arg Index: {1} Arg Value: {2} 
+  (Thread: {0}) Arg Index: {1} Arg Value: {2} 
 
 UIMA_CPM_lookup_cp__FINEST = Retrieving CasProcessor Configuration from CPEFactory. \
-  (Thread Name: {0}) CP name: {1} 
+  (Thread: {0}) CP name: {1} 
 
 
 UIMA_CPM_cp_no_name__SEVERE = The name of the CAS processor cannot be retrieved because the meta data cannot be accessed. \
-  (Thread Name: {0}).
+  (Thread: {0}).
 
-UIMA_CPM_reducing_cp_instance_count__FINEST = Reducing number of Cas Processor pool instances due to not enough services. \
-  (Thread Name: {0}) Cas Processor Name: {1} Using: {2} Deployment
+UIMA_CPM_reducing_cp_instance_count__FINEST = Reducing number of CAS Processor pool instances due to not enough services. \
+  (Thread: {0}) CAS Processor Name: {1} Using: {2} Deployment
 
 UIMA_CPM_invalid_cpe_descriptor__SEVERE = The CPE descriptor for the CAS processor {1} is invalid because element {2} cannot be found. \
-  (Thread Name: {0})
+  (Thread: {0})
 
-UIMA_CPM_launching_with_service_cmd__FINEST = Launching Cas Processor Application \
-  (Thread Name: {0}) Cas Processor Name: {1} Command Line Argument: {2} Value: {3}
+UIMA_CPM_launching_with_service_cmd__FINEST = Launching CAS Processor Application \
+  (Thread: {0}) CAS Processor Name: {1} Command Line Argument: {2} Value: {3}
 
-UIMA_CPM_launching_with_service_exec__FINEST = Launching Cas Processor Application \
-  (Thread Name: {0}) Cas Processor Name: {1} Exec Argument: {2} Value: {3}
+UIMA_CPM_launching_with_service_exec__FINEST = Launching CAS Processor Application \
+  (Thread: {0}) CAS Processor Name: {1} Exec Argument: {2} Value: {3}
 
-UIMA_CPM_launching_with_service_env__FINEST = Launching Cas Processor Application \
-  (Thread Name: {0}) Cas Processor Name: {1} Environment: {2} Value: {3}
+UIMA_CPM_launching_with_service_env__FINEST = Launching CAS Processor Application \
+  (Thread: {0}) CAS Processor Name: {1} Environment: {2} Value: {3}
 
 UIMA_CPM_connecting_to_services__FINEST = Connecting to Launched Services. \
-  (Thread Name: {0}) Cas Processor Name: {1} 
+  (Thread: {0}) CAS Processor Name: {1} 
 
 UIMA_CPM_unsupported_deploy_mode__SEVERE = The deployment mode {2} for the CAS processor {1} is not supported. Define the deployment mode as local, integrated or remote \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_deploy_vns__FINEST = Deploying Internal VNS: \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_deploy_vns_redeploy__FINEST = Deploying Internal VNS: \
-  (Thread Name: {0}) Redeploy Flag: {1} Restart Count: {2}
+  (Thread: {0}) Redeploy Flag: {1} Restart Count: {2}
 
 UIMA_CPM_undeploying_service__FINEST = Undeploying Service: \
-  (Thread Name: {0}) Service Name: {1} Service Port: {2}
+  (Thread: {0}) Service Name: {1} Service Port: {2}
 
 UIMA_CPM_service_deployed__FINEST = Service Deployed \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_no_service_proxy__SEVERE = The service proxy pool for the service {1} cannot be accessed. The service proxy pool is NULL \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_wait_for_service_proxy_pool__FINEST = Not ALL CasProcessors Checked In. Waiting Until CasProcessor Pool Has All Instances Checked-in. Sleeping for awhile ... \
-  (Thread Name: {0}) Service Name: {1}
+  (Thread: {0}) Service Name: {1}
 
 UIMA_CPM_service_connection_created__FINEST = Created Connection to Service \
-  (Thread Name: {0}) Host: {1} Port: {2}
+  (Thread: {0}) Host: {1} Port: {2}
   
 UIMA_CPM_sending_request__FINEST = Sending Request to Service \
-  (Thread Name: {0}) Host: {1} 
+  (Thread: {0}) Host: {1} 
   
 UIMA_CPM_processing_response__FINEST = Processing Response From Service \
-  (Thread Name: {0}) Host: {1} 
+  (Thread: {0}) Host: {1} 
   
 UIMA_CPM_invalid_container__SEVERE = The CAS processor container is NULL. \
-  (Thread Name: {0})
+  (Thread: {0})
 
 UIMA_CPM_service_connection_exception__FINEST = ServiceConnectionException on CAS. \
-  (Thread Name: {0}) Container: {1} Cas Processor: {2}
+  (Thread: {0}) Container: {1} CAS Processor: {2}
 
-UIMA_CPM_redeploy_cp__FINEST = Redeploying CasProcessor. \
-  (Thread Name: {0}) Container: {1} Cas Processor: {2}
+UIMA_CPM_redeploy_cp__FINEST = Re-deploying CasProcessor. \
+  (Thread: {0}) Container: {1} CAS Processor: {2}
 
-UIMA_CPM_redeploy_cp_done__FINEST = Done redeploying CasProcessor. \
-  (Thread Name: {0}) Container: {1} Cas Processor: {2}
+UIMA_CPM_redeploy_cp_done__FINEST = Done re-deploying CasProcessor. \
+  (Thread: {0}) Container: {1} CAS Processor: {2}
 
 UIMA_CPM_pipeline_exception__FINEST = The container {1} experienced an error. Is container paused: {2} \
-  (Thread Name: {0})
+  (Thread: {0})
   
 UIMA_CPM_unknown_thread__WARNING = Resource leak: detected non-UIMA thread [{0}] in CPM Thread Group which appears to be preventing the thread group to shut down. This message appears only once per thread!

--- a/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
+++ b/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
@@ -540,13 +540,13 @@ UIMA_CPM_done_scanning_q__FINEST = Done With Scanning The Queue. \
   (Thread: {0}) (Queue: {1})
 
 UIMA_CPM_expecte_seq_not_found__FINEST = Expected Sequence Not Found. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_show_queue_capacity__FINEST = Queue Capacity. \
   (Thread: {0}) (Queue: {1}) Queue Capacity: {2} Current Queue Size: {3}
 
 UIMA_CPM_wait_for_chunk__FINEST = No Expected Chunk Sequnce - Waiting Some More. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_timedout_waiting_for_chunk__FINEST = Timed Out While Waiting For Chunk Sequnce.. \
   (Thread: {0}) (Queue: {1}) Doc ID: {2}  Skipping the document.
@@ -603,7 +603,7 @@ UIMA_CPM_artifact_null__SEVERE = The artifact is empty. \
   (Thread: {0})
 
 UIMA_CPM_exit_pp__FINEST = Exiting from CPM Processing Unit. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_pp_terminated__FINEST = Processing Pipeline Completed Processing CAS. \
   (Thread: {0})
@@ -811,10 +811,10 @@ UIMA_CPM_cpm_not_running__WARNING = The CPM is not running. \
   (Thread: {0})
   
 UIMA_CPM_start_pp__FINEST = Starting Processing Pipeline. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
   
 UIMA_CPM_dequeue_artifact__FINEST = Dequeueing next artifact from queue. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_maxwait_for_artifact__FINEST = Max Wait for artifact. \
   (Thread: {0}) Wait Time: {1}
@@ -839,10 +839,10 @@ UIMA_CPM_exception_adding_eof__SEVERE = The following error message was returned
   (Thread: {0})
   
 UIMA_CPM_cc_completed__FINEST = CasConsumer Thread is Done. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_pus_completed__FINEST = All Processing Pipelined completed. Unloading Output Queue. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_cleaning_up_pus__FINEST = All PUs completed. Terminating Annotators and Cleaning Up. \
   (Thread: {0}) 
@@ -905,7 +905,7 @@ UIMA_CPM_access_control_file_not_found__FINEST = Control File Not Found. \
   (Thread: {0}) File Name: {1}
   
 UIMA_CPM_initialize_pipeline__FINEST = Initializing Processing Unit. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
   
 UIMA_CPM_timer_class__FINEST = Timer class for this run. \
   (Thread: {0}) Timer Class Name: {1}
@@ -1053,10 +1053,10 @@ UIMA_CPM_already_stopped__FINEST = Engine Already stopped. \
   (Thread: {0}) 
 
 UIMA_CPM_consuming_queue__FINEST = Consuming queue... \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_wait_consuming_queue__FINEST = Waiting for PU to consume queue. \
-  (Thread: {0}) (Queue: {1}) Queue Size: {2}
+  (Thread: {0}) (Queue: {1}) (Queue Size: {2})
 
 UIMA_CPM_done_consuming_queue__FINEST = Done consuming queues. \
   (Thread: {0}) 


### PR DESCRIPTION
- Refactor the CPMThreadGroup into a CPMExecutionService
- Replace Thread.join() calls with Future.get() calls
- Replace the ThreadGroupDestroyer thread a simple call to shutdown()
- Replace the uncaught exception handler with overriding ThreadPoolExecutor.afterExecute()
- Clean up and format few classes