### PR TITLE
[UIMA-6354] Limit permitted JDK to minimal JDK for release builds

### DIFF
--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -25,7 +25,9 @@
      project-wide parent pom.
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -107,14 +109,14 @@
       </snapshots>
     </repository>
     -->
-    
+
     <repository>
       <id>${eclipseP2RepoId}</id>
       <url>${eclipseP2RepoUrl}</url>
       <layout>p2</layout>
     </repository>
   </repositories>
-  
+
   <pluginRepositories>
     <!--
       - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
@@ -141,7 +143,7 @@
       <url>https://artifactory.openntf.org/openntf</url>
     </pluginRepository>
   </pluginRepositories>
-  
+
   <properties>
     <uimaScmRoot>uimaj</uimaScmRoot>
     <uimaScmProject>${project.artifactId}</uimaScmProject>
@@ -150,21 +152,21 @@
      Configuring settings is best done through default properties that multiple plugins.
      Local configurations within plugins should be avoided. Where plugins do not pick up default
      properties already, they should be injected manually into the plugins. 
-    --> 
+    -->
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>2.10.0</log4j.version>
     <jackson.version>2.9.2</jackson.version>
     <junit.version>5.7.2</junit.version>
-    
+
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    
+
     <eclipseP2RepoId>org.eclipse.p2.201812</eclipseP2RepoId>
     <eclipseP2RepoUrl>https://download.eclipse.org/releases/2018-12/</eclipseP2RepoUrl>
 
     <api_check_oldVersion>3.1.1</api_check_oldVersion>
   </properties>
-  
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -234,7 +236,7 @@
 
   <dependencies>
     <!-- Used to enable findbug rule suppression annotations -->
-    <!-- This is the Apache v2 license version -->      
+    <!-- This is the Apache v2 license version -->
     <dependency>
       <groupId>com.github.stephenc.findbugs</groupId>
       <artifactId>findbugs-annotations</artifactId>
@@ -254,7 +256,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  
+
     <plugins>
       <plugin>
         <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
@@ -276,14 +278,14 @@
           </dependency>
         </dependencies>
       </plugin>
-      
+
       <plugin>
         <groupId>org.openntf.maven</groupId>
         <artifactId>p2-layout-resolver</artifactId>
         <version>1.3.0</version>
         <extensions>true</extensions>
       </plugin>
-    
+
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
@@ -306,8 +308,40 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <profiles>
+    <profile>
+      <id>apache-release</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <!-- 
+                       - Ensure that releases are made with a Java 1.8 since that's our minimum
+                       - version atm.
+                       -->
+                      <version>[1.8,1.9)</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>jacoco</id>
       <build>


### PR DESCRIPTION
- Enforce that releases are made with a Java 1.8