### PR TITLE
[UIMA-6388] CAS.select(null) returns all annotations

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/CAS.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/CAS.java
@@ -1205,6 +1205,8 @@ public interface CAS extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <T extends TOP> SelectFSs<T> select(Type type) {
     return new SelectFSs_impl<>(this).type(type);
@@ -1217,6 +1219,8 @@ public interface CAS extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <T extends TOP> SelectFSs<T> select(Class<T> clazz) {
     return new SelectFSs_impl<>(this).type(clazz);
@@ -1230,6 +1234,8 @@ public interface CAS extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <T extends TOP> SelectFSs<T> select(int jcasType) {
     return new SelectFSs_impl<>(this).type(jcasType);
@@ -1242,6 +1248,8 @@ public interface CAS extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <T extends TOP> SelectFSs<T> select(String fullyQualifiedTypeName) {
     return new SelectFSs_impl<>(this).type(fullyQualifiedTypeName);

--- a/uimaj-core/src/main/java/org/apache/uima/cas/FSIndex.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/FSIndex.java
@@ -229,6 +229,8 @@ public interface FSIndex<T extends FeatureStructure> extends Collection<T> {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   <N extends T> SelectFSs<N> select(Type type);
 
@@ -239,6 +241,8 @@ public interface FSIndex<T extends FeatureStructure> extends Collection<T> {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   <N extends T> SelectFSs<N> select(Class<N> clazz);
 
@@ -260,6 +264,8 @@ public interface FSIndex<T extends FeatureStructure> extends Collection<T> {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   <N extends T> SelectFSs<N> select(String fullyQualifiedTypeName);
 

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/SelectFSs_impl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/SelectFSs_impl.java
@@ -192,16 +192,26 @@ public class SelectFSs_impl<T extends FeatureStructure> implements SelectFSs<T> 
     return this;
   }
 
-  /*
-   * TYPE if not specified defaults to the index's uppermost type.
+  /**
+   * Select the index's uppermost type.
    */
+  public <N extends T> SelectFSs_impl<N> anyType() {
+    this.ti = (TypeImpl) null;
+    return (SelectFSs_impl<N>) this;
+  }
 
   public <N extends T> SelectFSs_impl<N> type(Type uimaType) {
+    if (uimaType == null) {
+      throw new IllegalArgumentException("Must specify a type");
+    }
     this.ti = (TypeImpl) uimaType;
     return (SelectFSs_impl<N>) this;
   }
 
   public <N extends T> SelectFSs_impl<N> type(String fullyQualifiedTypeName) {
+    if (fullyQualifiedTypeName == null) {
+      throw new IllegalArgumentException("Must specify a type");
+    }
     this.ti = view.getTypeSystemImpl().getType(fullyQualifiedTypeName);
     return (SelectFSs_impl<N>) this;
   }
@@ -212,6 +222,9 @@ public class SelectFSs_impl<T extends FeatureStructure> implements SelectFSs<T> 
   }
 
   public <N extends T> SelectFSs_impl<N> type(Class<N> jcasClass_dot_class) {
+    if (jcasClass_dot_class == null) {
+      throw new IllegalArgumentException("Must specify a type");
+    }
     this.ti = (TypeImpl) view.getJCasImpl().getCasType(jcasClass_dot_class);
     return (SelectFSs_impl<N>) this;
   }
@@ -609,8 +622,9 @@ public class SelectFSs_impl<T extends FeatureStructure> implements SelectFSs<T> 
   }
 
   private void maybeValidateAltSource() {
-    if (!isAltSource)
+    if (!isAltSource) {
       return;
+    }
 
     if (index != null || boundsUse != BoundsUse.notBounded || isAllViews || isFollowing
             || isPreceding || startingFs != null) {
@@ -1717,8 +1731,9 @@ public class SelectFSs_impl<T extends FeatureStructure> implements SelectFSs<T> 
 
   @Override
   public boolean isEmpty() {
-    if (this.limit == 0)
+    if (this.limit == 0) {
       return true;
+    }
     return fsIterator().size() == 0;
   }
 

--- a/uimaj-core/src/main/java/org/apache/uima/jcas/JCas.java
+++ b/uimaj-core/src/main/java/org/apache/uima/jcas/JCas.java
@@ -1041,6 +1041,8 @@ public interface JCas extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <N extends TOP> SelectFSs<N> select(Type type) {
     return new SelectFSs_impl<>(getCasImpl()).type(type);
@@ -1053,6 +1055,8 @@ public interface JCas extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <N extends TOP> SelectFSs<N> select(Class<N> clazz) {
     return new SelectFSs_impl<>(getCasImpl()).type(clazz);
@@ -1078,6 +1082,8 @@ public interface JCas extends AbstractCas {
    *          the Type of the elements being accessed
    * @return a newly created selection object for accessing feature structures of that type and its
    *         subtypes
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <N extends TOP> SelectFSs<N> select(String fullyQualifiedTypeName) {
     return new SelectFSs_impl<>(getCasImpl()).type(fullyQualifiedTypeName);

--- a/uimaj-core/src/main/java/org/apache/uima/jcas/cas/FSList.java
+++ b/uimaj-core/src/main/java/org/apache/uima/jcas/cas/FSList.java
@@ -103,6 +103,8 @@ public abstract class FSList<T extends TOP> extends TOP implements CommonList, I
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   public <U extends T> SelectFSs<U> select(Type filterByType) {
     return new SelectFSs_impl<>(this).type(filterByType);
@@ -116,6 +118,8 @@ public abstract class FSList<T extends TOP> extends TOP implements CommonList, I
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   public <U extends T> SelectFSs<U> select(Class<U> filterByType) {
     return new SelectFSs_impl<>(this).type(filterByType);
@@ -138,10 +142,12 @@ public abstract class FSList<T extends TOP> extends TOP implements CommonList, I
    * Treat an FSArray as a source for SelectFSs.
    * 
    * @param filterByType
-   *          only includes elements of this type (fully qualifined type name)
+   *          only includes elements of this type (fully qualified type name)
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   public <U extends T> SelectFSs<U> select(String filterByType) {
     return new SelectFSs_impl<>(this).type(filterByType);

--- a/uimaj-core/src/main/java/org/apache/uima/jcas/cas/SelectViaCopyToArray.java
+++ b/uimaj-core/src/main/java/org/apache/uima/jcas/cas/SelectViaCopyToArray.java
@@ -55,6 +55,8 @@ public interface SelectViaCopyToArray<T extends FeatureStructure> {
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <U extends T> SelectFSs<U> select(Type filterByType) {
     return select().type(filterByType);
@@ -68,6 +70,8 @@ public interface SelectViaCopyToArray<T extends FeatureStructure> {
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <U extends T> SelectFSs<U> select(Class<U> filterByType) {
     return select().type(filterByType);
@@ -94,6 +98,8 @@ public interface SelectViaCopyToArray<T extends FeatureStructure> {
    * @param <U>
    *          generic type being selected
    * @return a new instance of SelectFSs
+   * @throws IllegalArgumentException
+   *           if no type is specified.
    */
   default <U extends T> SelectFSs<U> select(String filterByType) {
     return select().type(filterByType);


### PR DESCRIPTION
- Check parameter value of type(xxx) selectors for a non-null parameter
- Added a anyType() selector to allow explicitly requesting any type (which is the default behavior anyway)
- Update JavaDoc