### PR TITLE
[UIMA-6401] CPE ThreadGroupDestroyer keeps unnecessary reference on CPMEngine

### DIFF
--- a/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
+++ b/uimaj-cpe/src/main/resources/org/apache/uima/collection/impl/cpm/cpm_messages.properties
@@ -850,9 +850,6 @@ UIMA_CPM_cleaning_up_pus__FINEST = All PUs completed. Terminating Annotators and
 UIMA_CPM_engine_stopped__FINEST = Engine Stopped. \
   (Thread: {0}) 
 
-UIMA_CPM_destroy_thread_group__FINEST = DESTROYING THREAD GROUP. \
-  (Thread: {0}) 
-
 UIMA_CPM_show_thread__FINEST = Thread Info. \
   (Thread: {0}) Thread Index: {1} CPE Thread Name: {2}
 
@@ -880,7 +877,7 @@ UIMA_CPM_use_custom_timer__FINEST = Using Custom Timer to Measure Performance. \
 UIMA_CPM_use_default_timer__FINEST = Using Default Timer to Measure Performance. \
   (Thread: {0})
   
-UIMA_CPM_unhandled_error__SEVERE = The CPM thread group caught the following unhandled error: {1} \
+UIMA_CPM_unhandled_error__SEVERE = The CPM executor service caught the following unhandled error: {1} \
   (Thread: {0}) 
   
 UIMA_CPM_checkpoint_target_not_defined__FINEST = DebugControlThread- Target To Checkpoint not defined. \
@@ -1464,5 +1461,3 @@ UIMA_CPM_redeploy_cp_done__FINEST = Done re-deploying CasProcessor. \
 
 UIMA_CPM_pipeline_exception__FINEST = The container {1} experienced an error. Is container paused: {2} \
   (Thread: {0})
-  
-UIMA_CPM_unknown_thread__WARNING = Resource leak: detected non-UIMA thread [{0}] in CPM Thread Group which appears to be preventing the thread group to shut down. This message appears only once per thread!


### PR DESCRIPTION
- Update message catalog and remove obsolete messages