### PR TITLE
[UIMA-6435] Vinci example descriptors do not work

### DIFF
--- a/uimaj-examples/src/main/deploy/vinci/Deploy_MeetingDetectorTAE.xml
+++ b/uimaj-examples/src/main/deploy/vinci/Deploy_MeetingDetectorTAE.xml
@@ -23,7 +23,7 @@
    
 <deployment name="Vinci Meeting Detector TAE">
   <service name="uima.tutorial.MeetingDetectorTAE" provider="vinci">
-    <parameter name="resourceSpecifierPath" value="C:/Program Files/apache-uima/examples/descriptors/tutorial/ex4/MeetingDetectorTAE.xml"/>
+    <parameter name="resourceSpecifierPath" value="descriptors/tutorial/ex4/MeetingDetectorTAE.xml"/>
     <parameter name="numInstances" value="1"/>
   </service>
 </deployment>

--- a/uimaj-examples/src/main/deploy/vinci/Deploy_PersonTitleAnnotator.xml
+++ b/uimaj-examples/src/main/deploy/vinci/Deploy_PersonTitleAnnotator.xml
@@ -23,7 +23,7 @@
    
 <deployment name="Vinci Person Title Annotator Service">
   <service name="uima.annotator.PersonTitleAnnotator" provider="vinci">
-    <parameter name="resourceSpecifierPath" value="C:/Program Files/apache-uima/examples/descriptors/analysis_engine/PersonTitleAnnotator.xml"/>
+    <parameter name="resourceSpecifierPath" value="descriptors/analysis_engine/PersonTitleAnnotator.xml"/>
     <parameter name="numInstances" value="1"/>
   </service>
 </deployment>

--- a/uimaj-examples/src/main/deploy/vinci/Deploy_XmiWriterWithTutorialTypeSystem.xml
+++ b/uimaj-examples/src/main/deploy/vinci/Deploy_XmiWriterWithTutorialTypeSystem.xml
@@ -23,7 +23,7 @@
    
 <deployment name="Vinci Service for XMI Writer CAS Consumer with Tutorial Type System">
   <service name="uima.consumer.XmiWriterWithTutorialTypeSystem" provider="vinci">
-    <parameter name="resourceSpecifierPath" value="C:/Program Files/apache-uima/examples/descriptors/cas_consumer/XmiWriterWithTutorialTypeSystem.xml"/>
+    <parameter name="resourceSpecifierPath" value="descriptors/cas_consumer/XmiWriterWithTutorialTypeSystem.xml"/>
     <parameter name="numInstances" value="1"/>
   </service>
 </deployment>


### PR DESCRIPTION
**What's in the PR**
- Use relative paths - relative to the example project so that the "Start Vinci service" launch config works

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
