### PR TITLE
[UIMA-6440] Stage release artifacts as part of the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 
   <properties>
     <jiraVersion>3.2.0SDK</jiraVersion>   
-    <assemblyFinalName>uimaj-${project.version}</assemblyFinalName> 
     <assemblyBinDescriptor>src/main/assembly/bin-without-jackson.xml</assemblyBinDescriptor> 
     <postNoticeText>${ibmNoticeText}</postNoticeText>    
   </properties>
@@ -323,6 +322,13 @@
     
     <profile>
       <id>apache-release</id>
+
+      <properties>
+        <releaseCandidateNum></releaseCandidateNum>
+        <staging-scm-root>scm:svn:https://dist.apache.org/repos/dist/dev/uima/</staging-scm-root>
+        <staging-local-root>${project.build.directory}/staging</staging-local-root>
+        <staging-folder>${project.artifactId}-${project.version}-RC-${staging-timestamp}-${candidate-id}</staging-folder>
+      </properties>
       
       <build>
         <!-- Run jira report -->
@@ -330,6 +336,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-changes-plugin</artifactId>
+            <inherited>false</inherited>
             <executions>
               <execution>
                 <id>default-cli</id>
@@ -337,9 +344,99 @@
                   <fixVersionIds>${jiraVersion}</fixVersionIds>
                 </configuration>
               </execution>
-            </executions>  
+            </executions>
           </plugin>
-        </plugins>     
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>generate-candidate-id</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+                <configuration>
+                  <buildNumberPropertyName>candidate-id</buildNumberPropertyName>
+                  <timestampPropertyName>staging-timestamp</timestampPropertyName>
+                  <shortRevisionLength>7</shortRevisionLength>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <phase>install</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${staging-local-root}/${staging-folder}" />
+                    <copy todir="${staging-local-root}/${staging-folder}">
+                      <fileset dir="${project.build.directory}">
+                        <include name="uimaj-${project.version}-*.zip"/>
+                        <include name="uimaj-${project.version}-*.zip.asc"/>
+                        <include name="uimaj-${project.version}-*.zip.sha512"/>
+                        <include name="uimaj-${project.version}-*.tar.gz"/>
+                        <include name="uimaj-${project.version}-*.tar.gz.asc"/>
+                        <include name="uimaj-${project.version}-*.tar.gz.sha512"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-scm-plugin</artifactId>
+            <inherited>false</inherited>
+            <configuration>
+              <connectionType>developerConnection</connectionType>
+              <developerConnectionUrl>${staging-scm-root}</developerConnectionUrl>
+            </configuration>
+            <executions>
+              <execution>
+                <id>checkout-staging</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>checkout</goal>
+                </goals>
+                <configuration>
+                  <checkoutDirectory>${staging-local-root}</checkoutDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-staging-files</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>add</goal>
+                </goals>
+                <configuration>
+                  <basedir>${staging-local-root}</basedir>
+                  <includes>${staging-folder}/**/*</includes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>commit-staging-files</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>checkin</goal>
+                </goals>
+                <configuration>
+                  <basedir>${staging-local-root}</basedir>
+                  <message>Staging release artifacts for ${project.artifactId}-${project.version}-RC-${staging-timestamp}-${candidate-id}</message>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
     

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14</version>
+    <version>15-SNAPSHOT</version>
   </parent>
 
   <artifactId>uimaj-parent</artifactId>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -83,6 +83,7 @@
       - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
       - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only
       - be enabled when really needed.
+    -->
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
@@ -94,7 +95,6 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    -->
 
     <repository>
       <id>${eclipseP2RepoId}</id>


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6440

**What's in the PR**
- Add several plugins and executions to the apache-release profile in the top-level POM to auto-stage the release candidate during a release build
- Removed unused 'assemblyFinalName' property

**How to test manually**
* Initialize a local svn repo: `svnadmin create /my/local/testrepo`
* Do a test build: `mvn -Papache-release -DskipTests -Dmaven.deploy.skip -Dstaging-scm-root='scm:svn:file:///my/local/testrepo/' -Denforcer.skip clean install`
* Check if the commit made it in `svn log file:///my/local/testrepo/`

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
