### PR TITLE
[#222] Support comparing test files irrespective of line endings

### DIFF
--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/SerDesCasIOTestUtils.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/SerDesCasIOTestUtils.java
@@ -131,6 +131,31 @@ public class SerDesCasIOTestUtils {
    * DESERIALIZE -> SERIALIZE scenarios using the reference data from the
    * serialize/compare-to-reference data.
    */
+  public static List<DesSerTestScenario> roundTripDesSerScenariosComparingFileContentsNormalizingNewlines(
+          Collection<CasDesSerCycleConfiguration> aDesSerCycles, String aCasFileName)
+          throws Exception {
+    Class<?> caller = getCallerClass();
+
+    List<DesSerTestScenario> confs = new ArrayList<>();
+
+    for (CasDesSerCycleConfiguration cycle : aDesSerCycles) {
+      try (Stream<DesSerTestScenario.Builder> builders = DesSerTestScenario.builderCases(caller,
+              cycle, ROUND_TRIP, aCasFileName)) {
+
+        builders.map(builder -> builder.withCycle(cycle::performCycle)
+                .withAssertion(DesSerTestScenario::assertFileContentsAreEqualNormalizingNewlines)
+                .build()) //
+                .forEach(confs::add);
+      }
+    }
+
+    return confs;
+  }
+
+  /**
+   * DESERIALIZE -> SERIALIZE scenarios using the reference data from the
+   * serialize/compare-to-reference data.
+   */
   public static List<DesSerTestScenario> roundTripDesSerScenariosComparingCasContents(
           Collection<CasDesSerCycleConfiguration> aDesSerCycles, String aCasFileName)
           throws Exception {

--- a/uimaj-core/src/test/java/org/apache/uima/cas/serdes/scenario/DesSerTestScenario.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/serdes/scenario/DesSerTestScenario.java
@@ -121,6 +121,12 @@ public class DesSerTestScenario implements Runnable {
     assertThat(contentOf(aTargetCasFile.toFile())).isEqualTo(contentOf(aReferenceCasFile.toFile()));
   }
 
+  public static void assertFileContentsAreEqualNormalizingNewlines(Path aTargetCasFile,
+          Path aReferenceCasFile) {
+    assertThat(contentOf(aTargetCasFile.toFile()))
+            .isEqualToNormalizingNewlines(contentOf(aReferenceCasFile.toFile()));
+  }
+
   /**
    * Builder to build {@link DesSerTestScenario}.
    */


### PR DESCRIPTION
**What's in the PR**
- Added `SerDesCasIOTestUtils.roundTripDesSerScenariosComparingFileContentsNormalizingNewlines`

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
