### PR TITLE
Issue #235: Misleading error message when JCas type is not registered

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/CASRuntimeException.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/CASRuntimeException.java
@@ -121,10 +121,17 @@ public class CASRuntimeException extends UIMARuntimeException {
    * supertypes "{3}".
    */
   public static final String JCAS_MISMATCH_SUPERTYPE = "JCAS_MISMATCH_SUPERTYPE";
+
   /**
    * JCas type "{0}" used in Java code, but was not declared in the XML type descriptor.
    */
   public static final String JCAS_TYPE_NOT_IN_CAS = "JCAS_TYPE_NOT_IN_CAS";
+
+  /**
+   * JCas type "{0}" defined in CAS type system and used in Java code, but was not registered in
+   * JCasRegistry.
+   */
+  public static final String JCAS_TYPE_NOT_IN_CAS_REGISTRY = "JCAS_TYPE_NOT_IN_CAS_REGISTRY";
 
   /**
    * CAS type system type "{0}" defines field "{1}" with range "{2}", but JCas class has range

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
@@ -2736,7 +2736,7 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
               "Missing UIMA type, JCas Class name: %s, index: %d, jcasRegisteredTypes size: %d%n",
               className, typeindex, jcasRegisteredTypes.size());
       dumpTypeSystem();
-      throw new CASRuntimeException(CASRuntimeException.JCAS_TYPE_NOT_IN_CAS, className);
+      throw new CASRuntimeException(CASRuntimeException.JCAS_TYPE_NOT_IN_CAS_REGISTRY, className);
     } else {
       throw new CASRuntimeException(CASRuntimeException.JCAS_UNKNOWN_TYPE_NOT_IN_CAS);
     }

--- a/uimaj-core/src/main/java/org/apache/uima/pear/util/FileUtil.java
+++ b/uimaj-core/src/main/java/org/apache/uima/pear/util/FileUtil.java
@@ -145,9 +145,8 @@ public class FileUtil {
       boolean extAccepted = true;
       if (_dirPath != null) {
         String parentDir = file.getParent();
-        dirAccepted = parentDir != null
-                && parentDir.replace(WINDOWS_SEPARATOR_CHAR, UNIX_SEPARATOR_CHAR)
-                        .startsWith(_dirPath);
+        dirAccepted = parentDir != null && parentDir
+                .replace(WINDOWS_SEPARATOR_CHAR, UNIX_SEPARATOR_CHAR).startsWith(_dirPath);
       }
       if (_fileExt != null) {
         extAccepted = file.getPath().toLowerCase().endsWith(_fileExt);
@@ -789,9 +788,8 @@ public class FileUtil {
       File file = new File(targetDir, jarEntry.getName());
 
       if (!normalizeToUnix(file.getCanonicalPath()).startsWith(prefix)) {
-        throw new IOException(
-                "Can only write within target folder [" + targetDir.getAbsolutePath()
-                        + "]. Please validate ZIP contents.");
+        throw new IOException("Can only write within target folder [" + targetDir.getAbsolutePath()
+                + "]. Please validate ZIP contents.");
       }
 
       File dir = file.getParentFile();

--- a/uimaj-core/src/main/resources/org/apache/uima/UIMAException_Messages.properties
+++ b/uimaj-core/src/main/resources/org/apache/uima/UIMAException_Messages.properties
@@ -557,6 +557,7 @@ JCAS_CAS_NOT_V3 = JCas Class "{0}", loaded from "{1}", is missing required const
 JCAS_MISSING_FIELD_ACCESSOR = JCas Class "{0}" is missing required field accessor, or access not permitted, for field "{1}" during {2} operation.
 JCAS_CAS_MISMATCH = CAS type system doesn''t match JCas Type definition for type "{0}".
 JCAS_TYPE_NOT_IN_CAS = JCas type "{0}" used in Java code,  but was not declared in the XML type descriptor.
+JCAS_TYPE_NOT_IN_CAS_REGISTRY = JCas type "{0}" defined in CAS type system and used in Java code, but was not registered in JCasRegistry.
 JCAS_UNKNOWN_TYPE_NOT_IN_CAS = Unknown JCas type used in Java code but was not declared or imported in the XML descriptor for this component.
 JCAS_FIELD_MISSING_IN_TYPE_SYSTEM = JCAS class "{0}" defines a UIMA field "{1}" but the UIMA type doesn''t define that field.
 JCAS_FIELD_ADJ_OFFSET_CHANGED = In JCAS class "{0}", UIMA field "{1}" was set up when this class was previously loaded and initialized, to have an adjusted offset of "{2}" but now the feature has a different adjusted offset of "{3}"; this may be due to something else other than type system commit actions loading and initializing the JCas class, or to having a different non-compatible type system for this class, trying to use a common JCas cover class, which is not supported. 

--- a/uimaj-core/src/test/java/org/apache/uima/pear/util/PearInstallationVerificationTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/pear/util/PearInstallationVerificationTest.java
@@ -42,28 +42,25 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class PearInstallationVerificationTest {
   @Test
-  public void testAePearVerification(@TempDir
-  File temp) throws Exception {
+  public void testAePearVerification(@TempDir File temp) throws Exception {
     assertThatPearInstalls(getFile("pearTests/analysisEngine.pear"), temp);
   }
 
   @Test
-  public void testCcPearVerification(@TempDir
-  File temp) throws Exception {
+  public void testCcPearVerification(@TempDir File temp) throws Exception {
     assertThatPearInstalls(getFile("pearTests/casConsumer.pear"), temp);
   }
 
   @Test
-  public void testTsPearVerification(@TempDir
-  File temp) throws Exception {
+  public void testTsPearVerification(@TempDir File temp) throws Exception {
     assertThatPearInstalls(getFile("pearTests/typeSystem.pear"), temp);
   }
 
   // TODO: create testcases for ci, cr, cpe pear packages
 
   @Test
-  public void thatSpecialXmlCharactersInTargetPathDoNotBreakInstallation(@TempDir
-  File temp) throws Exception {
+  public void thatSpecialXmlCharactersInTargetPathDoNotBreakInstallation(@TempDir File temp)
+          throws Exception {
     File folder = new File(temp, "!'&");
     folder.mkdirs();
     assertThatPearInstalls(getFile("pearTests/analysisEngine.pear"),


### PR DESCRIPTION
**What's in the PR**
- Add new message
- Use this message when an unregistered but defined type is being used

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
