### PR TITLE
Issue #226: Provide SPI interfaces to locate descriptors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,5 @@
 * [ ] PR adds/updates documentation
 
 **Organizational**
-- [ ] PR includes new dependencies.
+- [ ] PR adds/updates dependencies.
       <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .project
 .settings
 target
-META-INF
 checkpoint_synchPoint.xml
 checkpoint_synchPoint.xml.prev
 checkpoint.dat

--- a/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.spi.adoc
+++ b/uima-doc-v3-users-guide/src/docs/asciidoc/uv3.spi.adoc
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+[[_uv3.custom_java_objects]]
+= Type discovery via SPI
+
+JCas types and associated type system descriptions can be made discoverable by UIMA using Java's
+SPI mechanism. 
+
+NOTE: The core UIMA Java SDK currently only this mechanism to discover JCas classes. SPI-based
+      auto-discovery of type system descriptions is supported by uimaFIT 3.4.0 and higher.
+
+SPI-based JCas class discovery is important in situation where multiple classloaders are used, e.g.
+in OSGi environments. This is because JCas classes must be globally unique in the entire system
+(with the exception of PEARs which can have their own JCas classes). So if JCas classes are to be
+provided through different class loaders (e.g. OSGI bundle classloaders), they must be announced via
+SPI, otherwise UIMA will not be able to reliably associated the JCas classes with their unique 
+classloader.
+
+To announce JCas classes via SPI, create a file `META-INF/services/org.apache.uima.spi.JCasClassProvider`
+and in the file, place implementations of the interface `org.apache.uima.spi.JCasClassProvider`, one 
+per line.
+
+Here is a trivial example implementation of the interface that announces two JCas classes.
+
+[source]
+----
+public class MyJCasClassProvider implements JCasClassProvider {
+
+  @Override
+  public List<Class<? extends TOP>> listJCasClasses() {
+    return asList(MyToken.class, MySentence.class);
+  }
+}
+----
+
+More elaborate implementations might e.g. use uimaFIT to auto-detect types and if there is a JCas
+class for any of these types, announce them.

--- a/uima-doc-v3-users-guide/src/docs/asciidoc/version_3_users_guide.adoc
+++ b/uima-doc-v3-users-guide/src/docs/asciidoc/version_3_users_guide.adoc
@@ -34,6 +34,8 @@ include::uv3.select.adoc[leveloffset=+1]
 
 include::uv3.annotation_predicates.adoc[leveloffset=+1]
 
+include::uv3.spi.adoc[leveloffset=+1]
+
 include::uv3.custom_java_objects.adoc[leveloffset=+1]
 
 include::uv3.logging.adoc[leveloffset=+1]

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -260,7 +260,8 @@
                   <exclude>src/test/resources/pearTests/*.pear</exclude>
                   <exclude>src/test/resources/pearTests/encodingTests/*</exclude>
                   <exclude>src/test/resources/SequencerTest/*.txt</exclude>
-                  <exclude>src/test/resources/SerDes*/SavedInts.binary</exclude> 
+                  <exclude>src/test/resources/SerDes*/SavedInts.binary</exclude>
+                  <exclude>src/test/resources/META-INF/services/org.apache.uima.spi.JCasClassProvider</exclude>
                   <!-- jcas classes generated -->
                   <exclude>src/test/java/aa/*.java</exclude>
                   <exclude>src/test/java/org/apache/uima/cas/test/*.java</exclude>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -264,6 +264,8 @@
                   <!-- jcas classes generated -->
                   <exclude>src/test/java/aa/*.java</exclude>
                   <exclude>src/test/java/org/apache/uima/cas/test/*.java</exclude>
+                  <exclude>src/test/java/org/apache/uima/spi/SpiToken.java</exclude>
+                  <exclude>src/test/java/org/apache/uima/spi/SpiSentence.java</exclude>
                   <exclude>src/test/java/org/apache/lang/LanguagePair.java</exclude>
                   <exclude>src/test/java/sofa/test/CrossAnnotation.java</exclude>
                   <exclude>src/test/java/x/y/z/*.java</exclude>

--- a/uimaj-core/src/main/java/org/apache/uima/spi/JCasClassProvider.java
+++ b/uimaj-core/src/main/java/org/apache/uima/spi/JCasClassProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.spi;
+
+import java.util.List;
+
+import org.apache.uima.jcas.cas.TOP;
+
+public interface JCasClassProvider {
+  List<Class<? extends TOP>> listJCasClasses();
+}

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
@@ -24,11 +24,11 @@ import static org.assertj.core.api.Assertions.entry;
 import java.util.Map;
 
 import org.apache.uima.UIMAFramework;
-import org.apache.uima.cas.test.Sentence;
-import org.apache.uima.cas.test.Token;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.resource.ResourceManager;
+import org.apache.uima.spi.SpiSentence;
+import org.apache.uima.spi.SpiToken;
 import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.Level;
 import org.junit.Before;
@@ -96,8 +96,8 @@ public class FSClassRegistryTest {
             .loadJCasClassesFromSPI(getClass().getClassLoader());
 
     assertThat(jcasClasses).containsOnly( //
-            entry(Token.class.getName(), Token.class), //
-            entry(Sentence.class.getName(), Sentence.class));
+            entry(SpiToken.class.getName(), SpiToken.class), //
+            entry(SpiSentence.class.getName(), SpiSentence.class));
   }
 
   private void assertRegisteredClassLoaders(int aExpectedCount, String aDescription) {

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
@@ -19,9 +19,15 @@
 package org.apache.uima.cas.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.Map;
 
 import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.test.Sentence;
+import org.apache.uima.cas.test.Token;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.Level;
@@ -82,6 +88,16 @@ public class FSClassRegistryTest {
 
       assertRegisteredClassLoaders(numberOfCachedClassloadersAtStart, "Only initial classloaders");
     }
+  }
+
+  @Test
+  public void thatJCasClassesCanBeLoadedThroughSPI() throws Exception {
+    Map<String, Class<? extends TOP>> jcasClasses = FSClassRegistry
+            .loadJCasClassesFromSPI(getClass().getClassLoader());
+
+    assertThat(jcasClasses).containsOnly( //
+            entry(Token.class.getName(), Token.class), //
+            entry(Sentence.class.getName(), Sentence.class));
   }
 
   private void assertRegisteredClassLoaders(int aExpectedCount, String aDescription) {

--- a/uimaj-core/src/test/java/org/apache/uima/jcas/test/generatedx.xml
+++ b/uimaj-core/src/test/java/org/apache/uima/jcas/test/generatedx.xml
@@ -1,350 +1,357 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
-	
-        <!--
-	 ***************************************************************
-	 * Licensed to the Apache Software Foundation (ASF) under one
-	 * or more contributor license agreements.  See the NOTICE file
-	 * distributed with this work for additional information
-	 * regarding copyright ownership.  The ASF licenses this file
-	 * to you under the Apache License, Version 2.0 (the
-	 * "License"); you may not use this file except in compliance
-	 * with the License.  You may obtain a copy of the License at
+<!--
+   ***************************************************************
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
          *
-	 *   http://www.apache.org/licenses/LICENSE-2.0
-	 * 
-	 * Unless required by applicable law or agreed to in writing,
-	 * software distributed under the License is distributed on an
-	 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-	 * KIND, either express or implied.  See the License for the
-	 * specific language governing permissions and limitations
-	 * under the License.
-	 ***************************************************************
+   *   http://www.apache.org/licenses/LICENSE-2.0
+   * 
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied.  See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   ***************************************************************
    -->
-
-
-<types>
-<typeDescription>
-<name>x.y.z.Sentence</name>
-<description/>
-<supertypeName>uima.tcas.Annotation</supertypeName>
-<features>
+  <types>
+    <typeDescription>
+      <name>x.y.z.Sentence</name>
+      <description />
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+      <features>
         <featureDescription>
           <name>sentenceLength</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.cas.Integer</rangeTypeName>
         </featureDescription>
       </features>
     </typeDescription>
-<typeDescription>
-<name>x.y.z.Token</name>
-<description/>
-<supertypeName>uima.tcas.Annotation</supertypeName>
-<features>
-<featureDescription>
-<name>ttype</name>
-<description/>
-<rangeTypeName>x.y.z.TokenType</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>tokenFloatFeat</name>
-<description/>
-<rangeTypeName>uima.cas.Float</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>lemma</name>
-<description/>
-<rangeTypeName>uima.cas.String</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>lemmaList</name>
-<description/>
-<rangeTypeName>uima.cas.StringArray</rangeTypeName>
-</featureDescription>
-</features>
-</typeDescription>
-<typeDescription>
-<name>x.y.z.TokenType</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-</typeDescription>
-<typeDescription>
-<name>x.y.z.Word</name>
-<description/>
-<supertypeName>x.y.z.TokenType</supertypeName>
-</typeDescription>
-<typeDescription>
-<name>x.y.z.Separator</name>
-<description/>
-<supertypeName>x.y.z.TokenType</supertypeName>
-</typeDescription>
-<typeDescription>
-<name>x.y.z.EndOfSentence</name>
-<description/>
-<supertypeName>x.y.z.TokenType</supertypeName>
-</typeDescription>
-<typeDescription>
-<name>org.apache.lang.LanguagePair</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-<features>
-<featureDescription>
-<name>lang1</name>
-<description/>
-<rangeTypeName>org.apache.lang.Group1</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>lang2</name>
-<description/>
-<rangeTypeName>org.apache.lang.Group2</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>description</name>
-<description/>
-<rangeTypeName>uima.cas.String</rangeTypeName>
-</featureDescription>
-</features>
-</typeDescription>
-<typeDescription>
-<name>org.apache.lang.Group1</name>
-<description/>
-<supertypeName>uima.cas.String</supertypeName>
-<allowedValues>
-<value>
-<string>"Chinese"</string>
-<description/>
-</value>
-<value>
-<string>"Japanese"</string>
-<description/>
-</value>
-<value>
-<string>"Korean"</string>
-<description/>
-</value>
-<value>
-<string>"English"</string>
-<description/>
-</value>
-<value>
-<string>"French"</string>
-<description/>
-</value>
-<value>
-<string>"German"</string>
-<description/>
-</value>
-<value>
-<string>"Italian"</string>
-<description/>
-</value>
-<value>
-<string>"Spanish"</string>
-<description/>
-</value>
-<value>
-<string>"Portuguese"</string>
-<description/>
-</value>
-</allowedValues>
-</typeDescription>
-<typeDescription>
-<name>org.apache.lang.Group2</name>
-<description/>
-<supertypeName>uima.cas.String</supertypeName>
-<allowedValues>
-<value>
-<string>"Arabic"</string>
-<description/>
-</value>
-<value>
-<string>"Czech"</string>
-<description/>
-</value>
-<value>
-<string>"Danish"</string>
-<description/>
-</value>
-<value>
-<string>"Dutch"</string>
-<description/>
-</value>
-<value>
-<string>"Finnish"</string>
-<description/>
-</value>
-<value>
-<string>"Greek"</string>
-<description/>
-</value>
-<value>
-<string>"Hebrew"</string>
-<description/>
-</value>
-<value>
-<string>"Hungarian"</string>
-<description/>
-</value>
-<value>
-<string>"Norwegian"</string>
-<description/>
-</value>
-<value>
-<string>"Polish"</string>
-<description/>
-</value>
-<value>
-<string>"Portuguese"</string>
-<description/>
-</value>
-<value>
-<string>"Russian"</string>
-<description/>
-</value>
-<value>
-<string>"Turkish"</string>
-<description/>
-</value>
-</allowedValues>
-</typeDescription>
-<typeDescription>
-<name>aa.Root</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-<features>
-<featureDescription>
-<name>arrayInt</name>
-<description/>
-<rangeTypeName>uima.cas.IntegerArray</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>arrayRef</name>
-<description/>
-<rangeTypeName>uima.cas.FSArray</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>arrayFloat</name>
-<description/>
-<rangeTypeName>uima.cas.FloatArray</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>arrayString</name>
-<description/>
-<rangeTypeName>uima.cas.StringArray</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>plainInt</name>
-<description/>
-<rangeTypeName>uima.cas.Integer</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>plainFloat</name>
-<description/>
-<rangeTypeName>uima.cas.Float</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>plainString</name>
-<description/>
-<rangeTypeName>uima.cas.String</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>plainRef</name>
-<description>TokenType testMissingImport;</description>
-<rangeTypeName>aa.Root</rangeTypeName>
-</featureDescription>
-<featureDescription>
+    <typeDescription>
+      <name>x.y.z.Token</name>
+      <description />
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+      <features>
+        <featureDescription>
+          <name>ttype</name>
+          <description />
+          <rangeTypeName>x.y.z.TokenType</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>tokenFloatFeat</name>
+          <description />
+          <rangeTypeName>uima.cas.Float</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>lemma</name>
+          <description />
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>lemmaList</name>
+          <description />
+          <rangeTypeName>uima.cas.StringArray</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
+      <name>x.y.z.TokenType</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>x.y.z.Word</name>
+      <description />
+      <supertypeName>x.y.z.TokenType</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>x.y.z.Separator</name>
+      <description />
+      <supertypeName>x.y.z.TokenType</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>x.y.z.EndOfSentence</name>
+      <description />
+      <supertypeName>x.y.z.TokenType</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>org.apache.lang.LanguagePair</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+      <features>
+        <featureDescription>
+          <name>lang1</name>
+          <description />
+          <rangeTypeName>org.apache.lang.Group1</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>lang2</name>
+          <description />
+          <rangeTypeName>org.apache.lang.Group2</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>description</name>
+          <description />
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
+      <name>org.apache.lang.Group1</name>
+      <description />
+      <supertypeName>uima.cas.String</supertypeName>
+      <allowedValues>
+        <value>
+          <string>"Chinese"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Japanese"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Korean"</string>
+          <description />
+        </value>
+        <value>
+          <string>"English"</string>
+          <description />
+        </value>
+        <value>
+          <string>"French"</string>
+          <description />
+        </value>
+        <value>
+          <string>"German"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Italian"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Spanish"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Portuguese"</string>
+          <description />
+        </value>
+      </allowedValues>
+    </typeDescription>
+    <typeDescription>
+      <name>org.apache.lang.Group2</name>
+      <description />
+      <supertypeName>uima.cas.String</supertypeName>
+      <allowedValues>
+        <value>
+          <string>"Arabic"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Czech"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Danish"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Dutch"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Finnish"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Greek"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Hebrew"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Hungarian"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Norwegian"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Polish"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Portuguese"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Russian"</string>
+          <description />
+        </value>
+        <value>
+          <string>"Turkish"</string>
+          <description />
+        </value>
+      </allowedValues>
+    </typeDescription>
+    <typeDescription>
+      <name>aa.Root</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+      <features>
+        <featureDescription>
+          <name>arrayInt</name>
+          <description />
+          <rangeTypeName>uima.cas.IntegerArray</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>arrayRef</name>
+          <description />
+          <rangeTypeName>uima.cas.FSArray</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>arrayFloat</name>
+          <description />
+          <rangeTypeName>uima.cas.FloatArray</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>arrayString</name>
+          <description />
+          <rangeTypeName>uima.cas.StringArray</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>plainInt</name>
+          <description />
+          <rangeTypeName>uima.cas.Integer</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>plainFloat</name>
+          <description />
+          <rangeTypeName>uima.cas.Float</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>plainString</name>
+          <description />
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>plainRef</name>
+          <description>TokenType testMissingImport;</description>
+          <rangeTypeName>aa.Root</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
           <name>plainLong</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.cas.Long</rangeTypeName>
         </featureDescription>
         <featureDescription>
           <name>plainDouble</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.cas.Double</rangeTypeName>
         </featureDescription>
         <featureDescription>
           <name>arrayLong</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.cas.LongArray</rangeTypeName>
         </featureDescription>
         <featureDescription>
           <name>arrayDouble</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.cas.DoubleArray</rangeTypeName>
         </featureDescription>
       </features>
-</typeDescription>
-<typeDescription>
-<name>aa.MissingInCas</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-</typeDescription>
-<typeDescription>
-<name>aa.MissingFeatureInCas</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-<features>
-<featureDescription>
-<name>haveThisOne</name>
-<description/>
-<rangeTypeName>uima.cas.Integer</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>missingThisOne</name>
-<description/>
-<rangeTypeName>uima.cas.Float</rangeTypeName>
-</featureDescription>
-<featureDescription>
-<name>changedFType</name>
-<description/>
-<rangeTypeName>uima.cas.String</rangeTypeName>
-</featureDescription>
-</features>
-</typeDescription>
-<typeDescription>
-<name>aa.AbstractType</name>
-<description/>
-<supertypeName>uima.cas.TOP</supertypeName>
-<features>
-<featureDescription>
-<name>abstractInt</name>
-<description/>
-<rangeTypeName>uima.cas.Integer</rangeTypeName>
-</featureDescription>
-</features>
-</typeDescription>
-<typeDescription>
-<name>aa.ConcreteType</name>
-<description/>
-<supertypeName>aa.AbstractType</supertypeName>
-<features>
-<featureDescription>
-<name>concreteString</name>
-<description/>
-<rangeTypeName>uima.cas.String</rangeTypeName>
-</featureDescription>
-</features>
-</typeDescription>
-<typeDescription>
+    </typeDescription>
+    <typeDescription>
+      <name>aa.MissingInCas</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>aa.MissingFeatureInCas</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+      <features>
+        <featureDescription>
+          <name>haveThisOne</name>
+          <description />
+          <rangeTypeName>uima.cas.Integer</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>missingThisOne</name>
+          <description />
+          <rangeTypeName>uima.cas.Float</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>changedFType</name>
+          <description />
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
+      <name>aa.AbstractType</name>
+      <description />
+      <supertypeName>uima.cas.TOP</supertypeName>
+      <features>
+        <featureDescription>
+          <name>abstractInt</name>
+          <description />
+          <rangeTypeName>uima.cas.Integer</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
+      <name>aa.ConcreteType</name>
+      <description />
+      <supertypeName>aa.AbstractType</supertypeName>
+      <features>
+        <featureDescription>
+          <name>concreteString</name>
+          <description />
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
       <name>org.apache.uima.cas.test.CrossAnnotation</name>
-      <description/>
+      <description />
       <supertypeName>uima.tcas.Annotation</supertypeName>
       <features>
         <featureDescription>
           <name>otherAnnotation</name>
-          <description/>
+          <description />
           <rangeTypeName>uima.tcas.Annotation</rangeTypeName>
         </featureDescription>
       </features>
     </typeDescription>
-  <typeDescription>
+    <typeDescription>
       <name>org.apache.uima.cas.test.Sentence</name>
-      <description/>
+      <description />
       <supertypeName>uima.tcas.Annotation</supertypeName>
     </typeDescription>
     <typeDescription>
       <name>org.apache.uima.cas.test.Token</name>
-      <description/>
+      <description />
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>org.apache.uima.spi.SpiToken</name>
+      <description />
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+    </typeDescription>
+    <typeDescription>
+      <name>org.apache.uima.spi.SpiSentence</name>
+      <description />
       <supertypeName>uima.tcas.Annotation</supertypeName>
     </typeDescription>
   </types>

--- a/uimaj-core/src/test/java/org/apache/uima/spi/JCasClassProviderForTesting.java
+++ b/uimaj-core/src/test/java/org/apache/uima/spi/JCasClassProviderForTesting.java
@@ -22,14 +22,12 @@ import static java.util.Arrays.asList;
 
 import java.util.List;
 
-import org.apache.uima.cas.test.Sentence;
-import org.apache.uima.cas.test.Token;
 import org.apache.uima.jcas.cas.TOP;
 
 public class JCasClassProviderForTesting implements JCasClassProvider {
 
   @Override
   public List<Class<? extends TOP>> listJCasClasses() {
-    return asList(Token.class, Sentence.class);
+    return asList(SpiToken.class, SpiSentence.class);
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/spi/JCasClassProviderForTesting.java
+++ b/uimaj-core/src/test/java/org/apache/uima/spi/JCasClassProviderForTesting.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.spi;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.apache.uima.cas.test.Sentence;
+import org.apache.uima.cas.test.Token;
+import org.apache.uima.jcas.cas.TOP;
+
+public class JCasClassProviderForTesting implements JCasClassProvider {
+
+  @Override
+  public List<Class<? extends TOP>> listJCasClasses() {
+    return asList(Token.class, Sentence.class);
+  }
+}

--- a/uimaj-core/src/test/java/org/apache/uima/spi/SpiSentence.java
+++ b/uimaj-core/src/test/java/org/apache/uima/spi/SpiSentence.java
@@ -1,0 +1,99 @@
+// @formatter:off
+/* Apache UIMA v3 - First created by JCasGen Mon Aug 15 10:39:23 CEST 2022 */
+
+package org.apache.uima.spi;
+ 
+
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** 
+ * Updated by JCasGen Mon Aug 15 10:39:23 CEST 2022
+ * XML source: /Users/bluefire/git/uima-uimaj/uimaj-core/src/test/java/org/apache/uima/jcas/test/generatedx.xml
+ * @generated */
+public class SpiSentence extends Annotation {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.apache.uima.spi.SpiSentence";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(SpiSentence.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+
+
+  /* Feature Adjusted Offsets */
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected SpiSentence() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public SpiSentence(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public SpiSentence(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public SpiSentence(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+}

--- a/uimaj-core/src/test/java/org/apache/uima/spi/SpiToken.java
+++ b/uimaj-core/src/test/java/org/apache/uima/spi/SpiToken.java
@@ -1,0 +1,99 @@
+// @formatter:off
+/* Apache UIMA v3 - First created by JCasGen Mon Aug 15 10:39:23 CEST 2022 */
+
+package org.apache.uima.spi;
+ 
+
+
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** 
+ * Updated by JCasGen Mon Aug 15 10:39:23 CEST 2022
+ * XML source: /Users/bluefire/git/uima-uimaj/uimaj-core/src/test/java/org/apache/uima/jcas/test/generatedx.xml
+ * @generated */
+public class SpiToken extends Annotation {
+ 
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static String _TypeName = "org.apache.uima.spi.SpiToken";
+  
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(SpiToken.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+ 
+  /* *******************
+   *   Feature Offsets *
+   * *******************/ 
+   
+
+
+  /* Feature Adjusted Offsets */
+
+   
+  /** Never called.  Disable default constructor
+   * @generated */
+  @Deprecated
+  @SuppressWarnings ("deprecation")
+  protected SpiToken() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param casImpl the CAS this Feature Structure belongs to
+   * @param type the type of this Feature Structure 
+   */
+  public SpiToken(TypeImpl type, CASImpl casImpl) {
+    super(type, casImpl);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public SpiToken(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public SpiToken(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+}

--- a/uimaj-core/src/test/resources/META-INF/services/org.apache.uima.spi.JCasClassProvider
+++ b/uimaj-core/src/test/resources/META-INF/services/org.apache.uima.spi.JCasClassProvider
@@ -1,0 +1,1 @@
+org.apache.uima.spi.JCasClassProviderForTesting

--- a/uimaj-ep-cas-editor-ide/.gitignore
+++ b/uimaj-ep-cas-editor-ide/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-cas-editor/.gitignore
+++ b/uimaj-ep-cas-editor/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-configurator/.gitignore
+++ b/uimaj-ep-configurator/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-debug/.gitignore
+++ b/uimaj-ep-debug/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-jcasgen/.gitignore
+++ b/uimaj-ep-jcasgen/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-launcher/.gitignore
+++ b/uimaj-ep-launcher/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-pear-packager/.gitignore
+++ b/uimaj-ep-pear-packager/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/

--- a/uimaj-ep-runtime/.gitignore
+++ b/uimaj-ep-runtime/.gitignore
@@ -1,2 +1,3 @@
 /.apt_generated/
 /.apt_generated_tests/
+/META-INF/


### PR DESCRIPTION
**What's in the PR**
- Added SPI for JCas classes
- Added test that FSClassRegistry is able to load JCas classes through the SPI
- Push exclusion of META-INF down into the bundle modules because we do not want to exclude the META-INF/services for SPI testing

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [x] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
