### PR TITLE
#238 - Form 6 serializes non-reachable FSes but should not

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes6.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/BinaryCasSerDes6.java
@@ -3044,7 +3044,7 @@ public class BinaryCasSerDes6 implements SlotKindsConstants {
     if (!isWrite) {
       // always have form 6 do just reachables, to mimic what v2 did
       AllFSs allFSs;
-      try (AutoCloseableNoException a = LowLevelCAS.ll_defaultV2IdRefs(false)) {
+      try (AutoCloseableNoException a = cas1.ll_enableV2IdRefs(false)) {
         allFSs = new AllFSs(cas1, mark, isTypeMapping ? fs -> isTypeInTgt(fs) : null,
                 isTypeMapping ? typeMapper : null).getAllFSsAllViews_sofas_reachable();
         // AllFSs internally already causes _save_to_cas_data() to be called, so we have to add all

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6Test.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/SerDesForm6Test.java
@@ -66,7 +66,6 @@ import org.apache.uima.internal.util.function.Runnable_withException;
 import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.util.AutoCloseableNoException;
 import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.impl.SerializationMeasures;
 import org.junit.jupiter.api.AfterEach;
@@ -417,15 +416,6 @@ public class SerDesForm6Test extends SerDesTstCommon {
             break;
         }
       }
-    }
-  }
-
-  @Test
-  public void testAllKindsV2() {
-    try (AutoCloseableNoException a = LowLevelCAS.ll_defaultV2IdRefs();
-            AutoCloseableNoException b = casSrc.ll_enableV2IdRefs()) { // because casSrc set in
-                                                                       // setup
-      testAllKinds();
     }
   }
 


### PR DESCRIPTION
**What's in the PR**
- Instead of only setting the default v2IdRef flag (which has no effect), set the flag on the CAS currently being processed
- Added unit test

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
