### PR TITLE
Issue #240: Helper annotation created by SelectFS should not survive

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -5240,8 +5240,10 @@ public class CASImpl extends AbstractCas_ImplBase
     List<TOP> all = new AllFSs(this, mark, includeFilter, typeMapper)
             .getAllFSsAllViews_sofas_reachable().getAllFSsSorted();
     List<TOP> filtered = filterAboveMark(all, mark);
-    for (TOP fs : filtered) {
-      action_filtered.accept(fs);
+    if (action_filtered != null) {
+      for (TOP fs : filtered) {
+        action_filtered.accept(fs);
+      }
     }
     return all;
   }
@@ -6164,6 +6166,13 @@ public class CASImpl extends AbstractCas_ImplBase
     if (enable && !restoreState && svd.fsIdGenerator != 0) {
       throw new IllegalStateException("CAS must be empty when switching to V2 ID References mode.");
     }
+    AutoCloseableNoException r = () -> svd.isId2Fs = restoreState;
+    svd.isId2Fs = enable;
+    return r;
+  }
+
+  AutoCloseableNoException ll_forceEnableV2IdRefs(boolean enable) {
+    final boolean restoreState = svd.isId2Fs;
     AutoCloseableNoException r = () -> svd.isId2Fs = restoreState;
     svd.isId2Fs = enable;
     return r;

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/SelectFSs_impl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/SelectFSs_impl.java
@@ -63,6 +63,7 @@ import org.apache.uima.jcas.cas.NonEmptyFSList;
 import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.jcas.impl.JCasImpl;
 import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.util.AutoCloseableNoException;
 
 // @formatter:off
 /**
@@ -1020,7 +1021,9 @@ public class SelectFSs_impl<T extends FeatureStructure> implements SelectFSs<T> 
     if (end < begin) {
       throw new IllegalArgumentException("End value must be >= Begin value");
     }
-    return new Annotation(jcas, begin, end);
+    try (AutoCloseableNoException c = ((CASImpl) jcas.getCas()).ll_forceEnableV2IdRefs(false)) {
+      return new Annotation(jcas, begin, end);
+    }
   }
 
 //@formatter:off


### PR DESCRIPTION
**What's in the PR**
- Prevent helper annotation from getting an ID and being held onto even when holding onto FSes is enabled
- Added unit test

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
