### PR TITLE
Issue #234: Using builtin annotation classes before creating a CAS can break type system management

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
@@ -673,6 +673,20 @@ public abstract class FSClassRegistry {
       jcci = maybeCreateJCasClassInfo(aTypeInfo, aClassLoader, aType2Jcci, aSpiJCasClasses);
     }
 
+    // Due to initialization order, it could be that we created the JCCI before the static fields in
+    // the JCas class have been initialized. In particular, the jcasType typeIndexID might still
+    // have been uninitialized (0) when we crated the JCCI. To work fix that case, check if the
+    // typeIndexID has changed and if so update the JCCI
+    if (jcci != null && jcci.jcasType == 0) {
+      if (!Modifier.isAbstract(jcci.jcasClass.getModifiers())) { // skip next for abstract classes
+        int jcasType = Misc.getStaticIntFieldNoInherit(jcci.jcasClass, "typeIndexID");
+        if (jcasType != jcci.jcasType) {
+          jcci = new JCasClassInfo(jcci.jcasClass, jcci.generator, jcasType);
+          type2jcci.put(ti.getJCasClassName(), jcci);
+        }
+      }
+    }
+
     // do this setup for new type systems using previously loaded jcci, as well as
     // for new jccis
     if (jcci != null && jcci.jcasType >= 0) {

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
@@ -673,20 +673,6 @@ public abstract class FSClassRegistry {
       jcci = maybeCreateJCasClassInfo(aTypeInfo, aClassLoader, aType2Jcci, aSpiJCasClasses);
     }
 
-    // Due to initialization order, it could be that we created the JCCI before the static fields in
-    // the JCas class have been initialized. In particular, the jcasType typeIndexID might still
-    // have been uninitialized (0) when we crated the JCCI. To work fix that case, check if the
-    // typeIndexID has changed and if so update the JCCI
-    if (jcci != null && jcci.jcasType == 0) {
-      if (!Modifier.isAbstract(jcci.jcasClass.getModifiers())) { // skip next for abstract classes
-        int jcasType = Misc.getStaticIntFieldNoInherit(jcci.jcasClass, "typeIndexID");
-        if (jcasType != jcci.jcasType) {
-          jcci = new JCasClassInfo(jcci.jcasClass, jcci.generator, jcasType);
-          type2jcci.put(ti.getJCasClassName(), jcci);
-        }
-      }
-    }
-
     // do this setup for new type systems using previously loaded jcci, as well as
     // for new jccis
     if (jcci != null && jcci.jcasType >= 0) {

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
@@ -388,6 +388,17 @@ public abstract class FSClassRegistry {
     return cl_to_type2JCas.size();
   }
 
+  /**
+   * Test support: checks whether the given class loader is currently registered in the global JCas
+   * class cache. Unlike {@link #clToType2JCasSize()}, this is not affected by other (unrelated) class
+   * loaders being asynchronously reaped from the underlying weak map.
+   */
+  static boolean isClToType2JCasRegistered(ClassLoader cl) {
+    synchronized (cl_to_type2JCas) {
+      return cl_to_type2JCas.get(cl) != null;
+    }
+  }
+
   private static void loadBuiltins(TypeImpl ti, ClassLoader cl,
           Map<String, JCasClassInfo> type2jcci, ArrayList<MutableCallSite> callSites_toSync) {
     String typeName = ti.getName();

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemConstants.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemConstants.java
@@ -101,23 +101,24 @@ public interface TypeSystemConstants {
   /**
    * adjOffsets for builtin Features
    */
-  int sofaNumFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaNumFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFANUM);
-  int sofaIdFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaIdFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFAID);
-  int sofaStringFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaStringFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFASTRING);
-  int sofaMimeFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaMimeFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFAMIME);
-  int sofaUriFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaUriFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFAURI);
-  int sofaArrayFeatAdjOffset = TypeSystemImpl.staticTsi.sofaType
+  int sofaArrayFeatAdjOffset = TypeSystemImpl.committedStaticTsi().sofaType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFAARRAY);
-  int annotBaseSofaFeatAdjOffset = TypeSystemImpl.staticTsi.annotBaseType
+  int annotBaseSofaFeatAdjOffset = TypeSystemImpl.committedStaticTsi().annotBaseType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_SOFA);
-  int beginFeatAdjOffset = TypeSystemImpl.staticTsi.annotType
+  int beginFeatAdjOffset = TypeSystemImpl.committedStaticTsi().annotType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_BEGIN);
-  int endFeatAdjOffset = TypeSystemImpl.staticTsi.annotType.getAdjOffset(CAS.FEATURE_BASE_NAME_END);
-  int langFeatAdjOffset = TypeSystemImpl.staticTsi.docType
+  int endFeatAdjOffset = TypeSystemImpl.committedStaticTsi().annotType
+          .getAdjOffset(CAS.FEATURE_BASE_NAME_END);
+  int langFeatAdjOffset = TypeSystemImpl.committedStaticTsi().docType
           .getAdjOffset(CAS.FEATURE_BASE_NAME_LANGUAGE);
 }

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
@@ -2868,18 +2868,9 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
 
   public static final TypeSystemImpl staticTsi = new TypeSystemImpl();
 
-  // staticTsi was previously committed inside this class's <clinit>. That triggered a recursive
-  // load-cover-classes storm: a built-in JCas cover class's <clinit> could be the very thing that
-  // caused TypeSystemImpl to load (e.g. via createCallSiteForBuiltIn). The commit then asked the
-  // JVM to fully initialize that same cover class while it was still mid-init on the current
-  // thread, producing a zero/default typeIndexID and broken callsites (issue #234). Commit is now
-  // deferred until first real demand via committedStaticTsi().
-  //
-  // Note: under deferred commit, another TypeSystemImpl with the same builtin-only structure may
-  // be committed before staticTsi is. In that case staticTsi.commit() consolidates to that other
-  // instance via committedTypeSystems (and staticTsi itself stays unfinalized). We therefore cache
-  // and return whatever commit() returns -- that is the instance with the correctly computed
-  // offsets.
+  // staticTsi.commit() can consolidate to a structurally-equivalent TypeSystemImpl that committed
+  // first, in which case staticTsi itself stays unfinalized. We cache and return whatever commit()
+  // returns -- that is the instance with the correctly computed offsets.
   private static volatile TypeSystemImpl committedStaticTsi;
 
   /**
@@ -3135,20 +3126,22 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
    */
   public static final MutableCallSite createCallSiteForBuiltIn(Class<? extends TOP> clazz,
           String featName) {
-    // If the static TSI has not yet been initialized, we assume that the initialization of the
-    // static TSI was not triggered by the given JCas cover class. So we return a default callsite
-    // and trust that it will be properly updated when the static TSI is committed.
-    if (staticTsi == null) {
+    // Use whichever staticTsi-equivalent instance has already been committed, if any. Reading the
+    // cached field directly (not via committedStaticTsi()) deliberately avoids forcing a commit
+    // from inside a built-in cover class's <clinit> -- that would reintroduce the issue-#234
+    // init-storm.
+    TypeSystemImpl committed = committedStaticTsi;
+    if (committed == null) {
+      // No commit has happened yet; return a default callsite that will be patched up by
+      // updateOrValidateAllCallSitesForJCasClass during the eventual commit.
       return createCallSite(clazz, featName);
     }
 
-    // If the given JCas cover class not registered yet, we also assume that the initialization of
-    // the static TSI was not triggered by the given JCas cover class.
     TypeImpl type;
     try {
       int typeId = clazz.getField("typeIndexID").getInt(null);
-      type = (typeId >= staticTsi.jcasRegisteredTypes.size()) ? null
-              : staticTsi.jcasRegisteredTypes.get(typeId);
+      type = (typeId >= committed.jcasRegisteredTypes.size()) ? null
+              : committed.jcasRegisteredTypes.get(typeId);
       if (type == null) {
         return createCallSite(clazz, featName);
       }

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
@@ -2867,11 +2867,40 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
   }
 
   public static final TypeSystemImpl staticTsi = new TypeSystemImpl();
-  static {
-    TypeSystemImpl tsi = staticTsi.commit(); // needed to assign adjusted offsets to the builtins
-    if (tsi != staticTsi) {
-      Misc.internalError();
+
+  // staticTsi was previously committed inside this class's <clinit>. That triggered a recursive
+  // load-cover-classes storm: a built-in JCas cover class's <clinit> could be the very thing that
+  // caused TypeSystemImpl to load (e.g. via createCallSiteForBuiltIn). The commit then asked the
+  // JVM to fully initialize that same cover class while it was still mid-init on the current
+  // thread, producing a zero/default typeIndexID and broken callsites (issue #234). Commit is now
+  // deferred until first real demand via committedStaticTsi().
+  //
+  // Note: under deferred commit, another TypeSystemImpl with the same builtin-only structure may
+  // be committed before staticTsi is. In that case staticTsi.commit() consolidates to that other
+  // instance via committedTypeSystems (and staticTsi itself stays unfinalized). We therefore cache
+  // and return whatever commit() returns -- that is the instance with the correctly computed
+  // offsets.
+  private static volatile TypeSystemImpl committedStaticTsi;
+
+  /**
+   * Returns a committed builtin-only {@link TypeSystemImpl} -- either {@link #staticTsi} itself if
+   * it was the first one to commit, or whatever structurally-equivalent committed instance it was
+   * consolidated to. Commit is performed lazily and exactly once across all threads. Code that
+   * needs commit-dependent state (e.g. {@link TypeImpl#getAdjOffset(String)}) must go through this
+   * accessor rather than reading {@link #staticTsi} directly.
+   */
+  public static TypeSystemImpl committedStaticTsi() {
+    TypeSystemImpl result = committedStaticTsi;
+    if (result == null) {
+      synchronized (TypeSystemImpl.class) {
+        result = committedStaticTsi;
+        if (result == null) {
+          result = staticTsi.commit();
+          committedStaticTsi = result;
+        }
+      }
     }
+    return result;
   }
 
 //@formatter:off

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/FSClassRegistryTest.java
@@ -25,7 +25,7 @@ import org.apache.uima.UIMAFramework;
 import org.apache.uima.spi.SpiSentence;
 import org.apache.uima.spi.SpiToken;
 import org.apache.uima.util.CasCreationUtils;
-import org.apache.uima.util.Level;
+import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,6 @@ class FSClassRegistryTest {
 
   @Test
   void thatCreatingResourceManagersWithExtensionClassloaderDoesNotFillUpCache() throws Exception {
-    int numberOfCachedClassloadersAtStart = FSClassRegistry.clToType2JCasSize();
     for (int i = 0; i < 5; i++) {
       var resMgr = UIMAFramework.newDefaultResourceManager();
       resMgr.setExtensionClassLoader(getClass().getClassLoader(), true);
@@ -56,19 +55,20 @@ class FSClassRegistryTest {
       assertThat(cl.getResource(FSClassRegistryTest.class.getName().replace(".", "/") + ".class")) //
               .isNotNull();
 
-      assertRegisteredClassLoaders(numberOfCachedClassloadersAtStart + 1,
-              "Only initial classloaders + the one owned by our ResourceManager");
+      assertClassLoaderRegistered(cl,
+              "Class loader owned by our ResourceManager should be registered after CAS creation")
+              .isTrue();
 
       resMgr.destroy();
 
-      assertRegisteredClassLoaders(numberOfCachedClassloadersAtStart, "Only initial classloaders");
+      assertClassLoaderRegistered(cl,
+              "Class loader owned by our ResourceManager should be unregistered after destroy")
+              .isFalse();
     }
   }
 
   @Test
   void thatCreatingResourceManagersWithExtensionPathDoesNotFillUpCache() throws Exception {
-    var numberOfCachedClassloadersAtStart = FSClassRegistry.clToType2JCasSize();
-
     for (int i = 0; i < 5; i++) {
       var resMgr = UIMAFramework.newDefaultResourceManager();
       resMgr.setExtensionClassPath("src/test/java", true);
@@ -78,12 +78,15 @@ class FSClassRegistryTest {
       assertThat(cl.getResource(FSClassRegistryTest.class.getName().replace(".", "/") + ".java")) //
               .isNotNull();
 
-      assertRegisteredClassLoaders(numberOfCachedClassloadersAtStart + 1,
-              "Only initial classloaders + the one owned by our ResourceManager");
+      assertClassLoaderRegistered(cl,
+              "Class loader owned by our ResourceManager should be registered after CAS creation")
+              .isTrue();
 
       resMgr.destroy();
 
-      assertRegisteredClassLoaders(numberOfCachedClassloadersAtStart, "Only initial classloaders");
+      assertClassLoaderRegistered(cl,
+              "Class loader owned by our ResourceManager should be unregistered after destroy")
+              .isFalse();
     }
   }
 
@@ -96,13 +99,17 @@ class FSClassRegistryTest {
             entry(SpiSentence.class.getName(), SpiSentence.class));
   }
 
-  private void assertRegisteredClassLoaders(int aExpectedCount, String aDescription) {
-    if (FSClassRegistry.clToType2JCasSize() > aExpectedCount) {
-      FSClassRegistry.log_registered_classloaders(Level.INFO);
-    }
+  // Note: we deliberately do not assert on the absolute number of registered class loaders
+  // (FSClassRegistry.clToType2JCasSize()). That cache is a process-wide static weak map shared with
+  // all other tests running in the same JVM. Other test classes leave class loaders registered
+  // there, and because the keys are weakly referenced they are reaped asynchronously by the GC -
+  // which makes the absolute size non-deterministic and was the cause of flaky failures. Instead we
+  // assert on the registration state of *our own* class loader, which we keep strongly reachable, so
+  // it is immune to other class loaders being reaped.
 
-    assertThat(FSClassRegistry.clToType2JCasSize()) //
-            .as(aDescription) //
-            .isEqualTo(aExpectedCount);
+  private AbstractBooleanAssert<?> assertClassLoaderRegistered(ClassLoader aClassLoader,
+          String aDescription) {
+    return assertThat(FSClassRegistry.isClToType2JCasRegistered(aClassLoader)) //
+            .as(aDescription);
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.jcas.impl;
+
+import static java.lang.System.getProperty;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces <a href="https://github.com/apache/uima-uimaj/issues/234">issue #234</a>: when a
+ * built-in Annotation cover class is touched before any CAS exists, the type system records a wrong
+ * (zero) jcasType for it and Annotation's feature callsites are never updated. Subsequent
+ * {@code getCasType} / {@code setBegin} calls then fail.
+ *
+ * <p>
+ * The bug only manifests in a fresh JVM where nothing has yet initialized {@link Annotation}. Class
+ * initialization is once-per-JVM, so running this in the shared Surefire JVM (where other tests
+ * have already created CASes and thereby initialized Annotation normally) would not reproduce it.
+ * The test therefore forks a dedicated JVM running {@link #main(String[])} and asserts on its exit
+ * code.
+ */
+public class LoadingBuiltinAnnotationBeforeCasTest {
+
+  /**
+   * Reproducer body. Must run in a fresh JVM (see the {@code @Test} below). Throws on failure so
+   * the JVM exits non-zero.
+   */
+  public static void main(String[] args) throws Exception {
+    // Force Annotation's <clinit> to start now, before any TypeSystemImpl / CAS exists.
+    // Annotation's super (AnnotationBase) references TypeSystemImpl in its own <clinit>, which
+    // kicks off a recursive init storm that reads Annotation.typeIndexID while it's still 0 --
+    // caching a broken JCasClassInfo and skipping Annotation's _FC_begin / _FC_end callsite update.
+    Class.forName(Annotation.class.getName());
+
+    var tsd = new TypeSystemDescription_impl();
+    var jcas = CasCreationUtils.createCas(tsd, null, null).getJCas();
+
+    // (1) Type system lookup by JCas type id. With the bug, slot Annotation.type of
+    // jcasRegisteredTypes is empty (the JCCI got registered at slot 0 instead).
+    jcas.getCasType(Annotation.type);
+
+    // (2) setDocumentText eventually calls Annotation.setBegin, which dispatches through the
+    // _FC_begin callsite. With the bug, that callsite still returns -1 and the offset lookup
+    // throws ArrayIndexOutOfBoundsException.
+    jcas.setDocumentText("hello");
+  }
+
+  @Test
+  void thatLoadingAnnotationBeforeCasDoesNotBreakTypeSystemManagement() throws Exception {
+    var windows = getProperty("os.name").toLowerCase().contains("win");
+    var java = getProperty("java.home") + File.separator + "bin" + File.separator
+            + (windows ? "java.exe" : "java");
+
+    var pb = new ProcessBuilder(java, "-cp", getProperty("java.class.path"), getClass().getName());
+    pb.redirectErrorStream(true);
+    var p = pb.start();
+
+    var buf = new ByteArrayOutputStream();
+    p.getInputStream().transferTo(buf);
+    int exit = p.waitFor();
+
+    assertThat(exit).as("forked JVM exited non-zero; subprocess output was:%n%s", buf.toString())
+            .isZero();
+  }
+}

--- a/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
@@ -20,9 +20,12 @@ package org.apache.uima.jcas.impl;
 
 import static java.lang.System.getProperty;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
@@ -80,9 +83,17 @@ public class LoadingBuiltinAnnotationBeforeCasTest {
 
     var buf = new ByteArrayOutputStream();
     p.getInputStream().transferTo(buf);
-    int exit = p.waitFor();
 
-    assertThat(exit).as("forked JVM exited non-zero; subprocess output was:%n%s", buf.toString())
+    // Bound the wait so a hypothetical class-init deadlock in the subprocess can't hang CI.
+    if (!p.waitFor(60, TimeUnit.SECONDS)) {
+      p.destroyForcibly();
+      fail("forked JVM did not exit within 60s; partial output was:%n%s",
+              buf.toString(StandardCharsets.UTF_8));
+    }
+
+    assertThat(p.exitValue())
+            .as("forked JVM exited non-zero; subprocess output was:%n%s",
+                    buf.toString(StandardCharsets.UTF_8))
             .isZero();
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/jcas/impl/LoadingBuiltinAnnotationBeforeCasTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
@@ -52,44 +51,50 @@ public class LoadingBuiltinAnnotationBeforeCasTest {
    * the JVM exits non-zero.
    */
   public static void main(String[] args) throws Exception {
-    // Force Annotation's <clinit> to start now, before any TypeSystemImpl / CAS exists.
-    // Annotation's super (AnnotationBase) references TypeSystemImpl in its own <clinit>, which
-    // kicks off a recursive init storm that reads Annotation.typeIndexID while it's still 0 --
-    // caching a broken JCasClassInfo and skipping Annotation's _FC_begin / _FC_end callsite update.
+    // Trigger Annotation's <clinit> before any TypeSystemImpl/CAS exists -- the bug repro hinge.
     Class.forName(Annotation.class.getName());
 
     var tsd = new TypeSystemDescription_impl();
     var jcas = CasCreationUtils.createCas(tsd, null, null).getJCas();
 
-    // (1) Type system lookup by JCas type id. With the bug, slot Annotation.type of
-    // jcasRegisteredTypes is empty (the JCCI got registered at slot 0 instead).
+    // (1) wrong jcasRegisteredTypes slot
     jcas.getCasType(Annotation.type);
 
-    // (2) setDocumentText eventually calls Annotation.setBegin, which dispatches through the
-    // _FC_begin callsite. With the bug, that callsite still returns -1 and the offset lookup
-    // throws ArrayIndexOutOfBoundsException.
+    // (2) Annotation._FC_begin callsite stuck at -1
     jcas.setDocumentText("hello");
   }
 
   @Test
   void thatLoadingAnnotationBeforeCasDoesNotBreakTypeSystemManagement() throws Exception {
-    var windows = getProperty("os.name").toLowerCase().contains("win");
-    var java = getProperty("java.home") + File.separator + "bin" + File.separator
-            + (windows ? "java.exe" : "java");
+    // Fork the same JVM that is running this test. ProcessHandle is best-effort, hence the
+    // fallback; the fallback path works on Windows too because CreateProcess auto-resolves .exe.
+    var java = ProcessHandle.current().info().command()
+            .orElse(getProperty("java.home") + "/bin/java");
 
     var pb = new ProcessBuilder(java, "-cp", getProperty("java.class.path"), getClass().getName());
     pb.redirectErrorStream(true);
     var p = pb.start();
 
+    // Drain the subprocess output on a daemon thread so that a deadlocked subprocess that never
+    // emits EOF can't block this thread from reaching the timed waitFor below.
     var buf = new ByteArrayOutputStream();
-    p.getInputStream().transferTo(buf);
+    var drain = new Thread(() -> {
+      try {
+        p.getInputStream().transferTo(buf);
+      } catch (Exception ignored) {
+        // Subprocess died mid-transfer; whatever we captured is what we report.
+      }
+    }, "forked-jvm-output-drain");
+    drain.setDaemon(true);
+    drain.start();
 
-    // Bound the wait so a hypothetical class-init deadlock in the subprocess can't hang CI.
     if (!p.waitFor(60, TimeUnit.SECONDS)) {
       p.destroyForcibly();
+      drain.join(5_000);
       fail("forked JVM did not exit within 60s; partial output was:%n%s",
               buf.toString(StandardCharsets.UTF_8));
     }
+    drain.join(5_000);
 
     assertThat(p.exitValue())
             .as("forked JVM exited non-zero; subprocess output was:%n%s",


### PR DESCRIPTION
**What's in the PR**
- Try fixing the case if a JCCI was created with a bad type ID because the type ID had not been set yet

**How to test manually**
* Try running the ClearTK `TimeMlAnnotateTest` _caugh_

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
