### PR TITLE
Issue #226: Provide SPI interfaces to locate descriptors and JCas classes

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
@@ -1753,7 +1753,7 @@ public abstract class FSClassRegistry { // abstract to prevent instantiating; th
   }
 
   private static final URL[] NO_URLS = new URL[0];
-  
+
   static Lookup getLookup(ClassLoader cl) {
     Lookup lookup = null;
     try {
@@ -1762,16 +1762,17 @@ public abstract class FSClassRegistry { // abstract to prevent instantiating; th
       // CL. This is in particular an issue for classes loaded through the SPI mechanism.
       UIMAClassLoader ucl;
       if (!(cl instanceof UIMAClassLoader)) {
-        ucl = cl_to_uimaCl.get(cl);
-        if (ucl == null ) {
-          ucl = new UIMAClassLoader(NO_URLS, cl);
-          cl_to_uimaCl.put(cl, ucl);
+        synchronized (cl_to_uimaCl) {
+          ucl = cl_to_uimaCl.get(cl);
+          if (ucl == null) {
+            ucl = new UIMAClassLoader(NO_URLS, cl);
+            cl_to_uimaCl.put(cl, ucl);
+          }
         }
-      } 
-      else {
+      } else {
         ucl = (UIMAClassLoader) cl;
       }
-      
+
       Class<?> clazz = Class.forName(UIMAClassLoader.MHLC, true, ucl);
       Method m = clazz.getMethod("getMethodHandlesLookup");
       lookup = (Lookup) m.invoke(null);

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FSClassRegistry.java
@@ -34,6 +34,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -197,6 +198,8 @@ public abstract class FSClassRegistry { // abstract to prevent instantiating; th
           .newHashMap(); // identity: key is classloader
   private static final WeakIdentityMap<ClassLoader, StackTraceElement[]> cl_to_type2JCasStacks;
   private static final WeakIdentityMap<ClassLoader, Map<String, Class<? extends TOP>>> cl_to_spiJCas = WeakIdentityMap
+          .newHashMap();
+  private static final WeakIdentityMap<ClassLoader, UIMAClassLoader> cl_to_uimaCl = WeakIdentityMap
           .newHashMap();
 
   // private static final Map<ClassLoader, Map<String, JCasClassInfo>> cl_4pears_to_type2JCas =
@@ -1749,10 +1752,27 @@ public abstract class FSClassRegistry { // abstract to prevent instantiating; th
     }
   }
 
+  private static final URL[] NO_URLS = new URL[0];
+  
   static Lookup getLookup(ClassLoader cl) {
     Lookup lookup = null;
     try {
-      Class<?> clazz = Class.forName(UIMAClassLoader.MHLC, true, cl);
+      // The UIMAClassLoader has special handling for the MHLC, so we must make sure that the CL
+      // we are using is actually a UIMAClassLoader, otherwise the MHCL will look up in the wrong
+      // CL. This is in particular an issue for classes loaded through the SPI mechanism.
+      UIMAClassLoader ucl;
+      if (!(cl instanceof UIMAClassLoader)) {
+        ucl = cl_to_uimaCl.get(cl);
+        if (ucl == null ) {
+          ucl = new UIMAClassLoader(NO_URLS, cl);
+          cl_to_uimaCl.put(cl, ucl);
+        }
+      } 
+      else {
+        ucl = (UIMAClassLoader) cl;
+      }
+      
+      Class<?> clazz = Class.forName(UIMAClassLoader.MHLC, true, ucl);
       Method m = clazz.getMethod("getMethodHandlesLookup");
       lookup = (Lookup) m.invoke(null);
     } catch (ClassNotFoundException | NoSuchMethodException | SecurityException


### PR DESCRIPTION
**What's in the PR**
- When obtaining a MH for a lookup through a custom classloader, make sure it is a UIMAClassLoader because otherwise the MHLC magic cannot work and the JCas classes get loaded through the wrong classloader - in particular applies to SPIs in an OSGI environment

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
