### PR TITLE
Issue #225: Improve deployment in OSGi environments

### DIFF
--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -103,8 +103,8 @@
 						<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
 						<_dsannotations>*</_dsannotations>
 						<_metatypeannotations>*</_metatypeannotations>
+						<Fragment-Host>org.apache.uima.j-core</Fragment-Host>
 						<Import-Package>
-							!org.apache.uima.collection.impl.metadata.cpe,
 							!com.apple.eio,
 							org.slf4j.impl;resolution:=optional,
 							org.apache.logging.log4j.*;resolution:=optional,


### PR DESCRIPTION
**What's in the PR**
- Turned uimaj-cpe into a fragment of uimaj-core because uimaj-core needs access to the packages of uimaj-cpe, e.g. because it accesses classes like CpeInclude via reflection in its factories

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
