### PR TITLE
Issue #252: Potential failure to look up FsGenerator3 in OSGI-like contexts

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/internal/util/UIMAClassLoader.java
+++ b/uimaj-core/src/main/java/org/apache/uima/internal/util/UIMAClassLoader.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import org.apache.uima.cas.impl.FSClassRegistry;
+import org.apache.uima.cas.impl.FsGenerator3;
 import org.apache.uima.cas.impl.TypeSystemImpl;
 
 /**
@@ -235,15 +236,23 @@ public class UIMAClassLoader extends URLClassLoader {
             c = findClass(name);
           }
         } catch (ClassNotFoundException e) {
-          // delegate class loading for this class-name
-          c = super.loadClass(name, false);
+          if (name.startsWith(FsGenerator3.class.getPackage().getName() + ".")) {
+            // There may be cases where the target class uses a classloader that has no access
+            // to the UIMA internal classes - in particular to the FSGenerator3 - so we force using
+            // the UIMA classloader in this case.
+            c = FsGenerator3.class.getClassLoader().loadClass(name);
+          } else {
+            // delegate class loading for this class-name
+            c = super.loadClass(name, false);
+          }
         }
       }
+
       if (resolve) {
         resolveClass(c);
       }
-      return c;
 
+      return c;
     }
   }
 


### PR DESCRIPTION
**What's in the PR**
- If the class to be looked up is in the FsGenerator3 package, use the classloader of FsGenerator3

**How to test manually**
* No specific test scenario

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
