### PR TITLE
#267 - UIMA Log4jLogger_impl not compatible with log4j 2.18.0+

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/util/impl/Log4jLogger_impl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/util/impl/Log4jLogger_impl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.uima.util.impl;
 
+import java.lang.reflect.Field;
 import java.text.MessageFormat;
 
 import org.apache.logging.log4j.LogManager;
@@ -241,7 +242,23 @@ public class Log4jLogger_impl extends Logger_common_impl {
   }
 
   private static org.apache.logging.log4j.Marker m(Marker m) {
-    return (m == null) ? null : ((org.apache.logging.slf4j.Log4jMarker) m).getLog4jMarker();
+    if (m == null) {
+      return null;
+    }
+
+    Field markerField = null;
+    try {
+      markerField = m.getClass().getDeclaredField("marker");
+      markerField.setAccessible(true);
+      return (org.apache.logging.log4j.Marker) markerField.get(m);
+    } catch (Exception e) {
+      // Well, best effort...
+      return null;
+    } finally {
+      if (markerField != null) {
+        markerField.setAccessible(false);
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
**What's in the PR**
- Use reflection to pry-open a protected class that was previously public - frankly, this is not a good solution...

**How to test manually**
* Upgrade to log42 2.18.0 and build
* Upgrade to log42 2.18.0 and run with Java 17

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
