### PR TITLE
Issue #285: NPE while deserializing an XMI in a PEAR context

### DIFF
--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/CASImpl.java
@@ -729,8 +729,13 @@ public class CASImpl extends AbstractCas_ImplBase
       id2fs.clear();
 
       // pear caches
-      id2tramp = null;
-      id2base = null;
+      if (id2tramp != null) {
+        id2tramp.clear();
+      }
+      if (id2base != null) {
+        id2base.clear();
+      }
+
       for (Iterator<Entry<ClassLoader, JCasHashMap>> it = cl2id2tramp.entrySet().iterator(); it
               .hasNext();) {
         Entry<ClassLoader, JCasHashMap> e = it.next();


### PR DESCRIPTION
**What's in the PR**
- If the id2base and id2tramp maps exist, only clear them, do not set them to null
- Added unit test

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
