### PR TITLE
#298 - SHA512 checksums contain wrong file name

### DIFF
--- a/PearPackagingMavenPlugin/pom.xml
+++ b/PearPackagingMavenPlugin/pom.xml
@@ -72,8 +72,4 @@
       <version>2.11.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <finalName>uima-pear-maven-plugin</finalName>
-  </build>
 </project>

--- a/jVinci/pom.xml
+++ b/jVinci/pom.xml
@@ -43,8 +43,6 @@
 	</properties>
 
 	<build>
-		<finalName>jVinci</finalName>
-
 		<plugins>
 			<plugin>
 				<groupId>org.apache.felix</groupId>

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -71,8 +71,6 @@
   </dependencies>
   
   <build>
-    <finalName>uima-adapter-vinci</finalName>
-    
 		<plugins>
 			<plugin>
 				<groupId>org.apache.felix</groupId>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -179,7 +179,6 @@
   </dependencies>
 
   <build>
-    <finalName>uima-core</finalName>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/uimaj-cpe/pom.xml
+++ b/uimaj-cpe/pom.xml
@@ -72,7 +72,6 @@
     </dependency>
   </dependencies>
   <build>
-    <finalName>uima-cpe</finalName>
     <pluginManagement>
       <!-- remove this once test case cleans up after itself -->
       <plugins>

--- a/uimaj-document-annotation/pom.xml
+++ b/uimaj-document-annotation/pom.xml
@@ -57,7 +57,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <finalName>uima-document-annotation</finalName>
-  </build>
 </project>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -119,8 +119,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.caseditor.ide_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -131,8 +131,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.caseditor_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/uimaj-ep-configurator/pom.xml
+++ b/uimaj-ep-configurator/pom.xml
@@ -103,8 +103,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.desceditor_${parsedVersion.osgiVersion}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-ep-debug/pom.xml
+++ b/uimaj-ep-debug/pom.xml
@@ -61,8 +61,6 @@ UIMA data structures to the Eclipse Debug displays</description>
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.debug_${parsedVersion.osgiVersion}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-ep-jcasgen/pom.xml
+++ b/uimaj-ep-jcasgen/pom.xml
@@ -95,9 +95,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.jcas.jcasgenp_${parsedVersion.osgiVersion}</finalName>
-
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-ep-launcher/pom.xml
+++ b/uimaj-ep-launcher/pom.xml
@@ -77,8 +77,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.launcher_${parsedVersion.osgiVersion}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-ep-pear-packager/pom.xml
+++ b/uimaj-ep-pear-packager/pom.xml
@@ -86,8 +86,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.pear_${parsedVersion.osgiVersion}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-ep-runtime/pom.xml
+++ b/uimaj-ep-runtime/pom.xml
@@ -91,8 +91,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.runtime_${parsedVersion.osgiVersion}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/uimaj-examples/pom.xml
+++ b/uimaj-examples/pom.xml
@@ -90,7 +90,6 @@
     </dependency>
   </dependencies>
   <build>
-    <finalName>uima-examples</finalName>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/uimaj-tools/pom.xml
+++ b/uimaj-tools/pom.xml
@@ -67,7 +67,6 @@
 
 	</dependencies>
 	<build>
-		<finalName>uima-tools</finalName>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>

--- a/uimaj-v3migration-jcas/pom.xml
+++ b/uimaj-v3migration-jcas/pom.xml
@@ -68,8 +68,4 @@
       <version>0.5.32</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <finalName>uimaj-v3migration-jcas</finalName>
-  </build>
 </project>


### PR DESCRIPTION
**What's in the PR**
- Remove finalName override from the build section

**How to test manually**
* Check that the checksum files now contain the proper filename
* Run release build
* Check if Eclipse plugins can still be installed
* Check if examples are still there 
* Check that descriptors can still be opened using Eclipse plugins
* Check that at least one of the launch configs shipped with UIMA still works

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
