### PR TITLE
Issue #303: Build fails on Windows if namespace contains whitespace

### DIFF
--- a/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/ImportResolverTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/ImportResolverTest.java
@@ -337,7 +337,7 @@ public class ImportResolverTest {
           Entry<File, TypeSystemDescription> otherTsd = allTypeSystemEntriesIterator.next();
           Import tsdImport = getResourceSpecifierFactory().createImport();
           // toURL is used intentionally here because we do not want the chars to get escaped
-          tsdImport.setLocation(otherTsd.getKey().toURI().toURL().toString());
+          tsdImport.setLocation(otherTsd.getKey().toURL().toString());
           imports.add(tsdImport);
           importedTypes.addAll(filesWithTransitiveTypes.get(otherTsd.getKey()));
           importedFiles.add(otherTsd.getKey());
@@ -405,10 +405,10 @@ public class ImportResolverTest {
     assertThat(ts.getTypes()).hasSize(2);
 
     Map<String, XMLizable> cache = resMgr.getImportCache();
-    assertThat(cache).containsOnlyKeys(circular2.toURI().toURL().toString());
+    assertThat(cache).containsOnlyKeys(circular2.toURL().toString());
 
     TypeSystemDescription cachedCircular2Tsd = (TypeSystemDescription) cache
-            .get(circular2.toURI().toURL().toString());
+            .get(circular2.toURL().toString());
     assertThat(ts.getTypes()).hasSize(2);
     assertThat(cachedCircular2Tsd.getTypes()).hasSize(1);
   }
@@ -424,13 +424,12 @@ public class ImportResolverTest {
     assertThat(ts.getTypes()).hasSize(3);
 
     Map<String, XMLizable> cache = resMgr.getImportCache();
-    assertThat(cache).containsOnlyKeys(circular2.toURI().toURL().toString(),
-            circular3.toURI().toURL().toString());
+    assertThat(cache).containsOnlyKeys(circular2.toURL().toString(), circular3.toURL().toString());
 
     TypeSystemDescription cachedCircular2Tsd = (TypeSystemDescription) cache
-            .get(circular2.toURI().toURL().toString());
+            .get(circular2.toURL().toString());
     TypeSystemDescription cachedCircular3Tsd = (TypeSystemDescription) cache
-            .get(circular3.toURI().toURL().toString());
+            .get(circular3.toURL().toString());
     assertThat(ts.getTypes()).hasSize(3);
     assertThat(cachedCircular2Tsd.getTypes()).hasSize(1);
     assertThat(cachedCircular3Tsd.getTypes()).hasSize(1);
@@ -486,7 +485,7 @@ public class ImportResolverTest {
   @Test
   public void thatImportFromProgrammaticallyCreatedTypeSystemDescriptionWorks() throws Exception {
     ResourceManager resMgr = newDefaultResourceManager();
-    URL url = getFile("TypeSystemDescriptionImplTest").toURI().toURL();
+    URL url = getFile("TypeSystemDescriptionImplTest").toURL();
 
     // test import from programatically created TypeSystemDescription
     Import_impl[] imports = { new Import_impl() };

--- a/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/ImportResolverTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/ImportResolverTest.java
@@ -101,10 +101,10 @@ public class ImportResolverTest {
     assertThat(ts.getTypes()).as("Type count after resolving the descriptor").hasSize(3);
     assertThat(ts.getImports()).hasSize(0);
 
-    String typeSystem2 = new File(descriptor.getParent(), "Transitive-with-3-nodes-2.xml").toURI()
-            .toURL().toString();
-    String typeSystem3 = new File(descriptor.getParent(), "Transitive-with-3-nodes-3.xml").toURI()
-            .toURL().toString();
+    String typeSystem2 = new File(descriptor.getParent(), "Transitive-with-3-nodes-2.xml").toURL()
+            .toString();
+    String typeSystem3 = new File(descriptor.getParent(), "Transitive-with-3-nodes-3.xml").toURL()
+            .toString();
 
     Map<String, XMLizable> cache = resMgr.getImportCache();
     assertThat(cache).containsOnlyKeys(typeSystem2, typeSystem3);

--- a/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
@@ -28,12 +28,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.io.File;
-import java.net.URI;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.ResourceManager;
@@ -128,8 +127,7 @@ public class TypeSystemDescription_implTest {
     assertThat(ts.getTypes()) //
             .as("Types after resolving the descriptor.") //
             .extracting( //
-                    t -> Paths.get(URI.create(t.getSourceUrlString())).getFileName().toString(),
-                    TypeDescription::getName) //
+                    t -> FilenameUtils.getName(t.getSourceUrlString()), TypeDescription::getName) //
             .containsExactlyInAnyOrder( //
                     tuple("TestTypeSystem.xml", "NamedEntity"), //
                     tuple("TestTypeSystem.xml", "Person"), //

--- a/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
@@ -154,13 +154,13 @@ public class TypeSystemDescription_implTest {
 
     String typeSystemImportedByLocation = new File(
             "target/test-classes/TypeSystemDescriptionImplTest/TypeSystemImportedByLocation.xml")
-                    .toURI().toURL().toString();
+                    .toURL().toString();
     String typeSystemImportedFromDataPath = new File(
             "target/test-classes/TypeSystemDescriptionImplTest/dataPathDir/TypeSystemImportedFromDataPath.xml")
-                    .toURI().toURL().toString();
+                    .toURL().toString();
     String typeSystemImportedByName = new File(
             "target/test-classes/org/apache/uima/resource/metadata/impl/TypeSystemImportedByName.xml")
-                    .toURI().toURL().toString();
+                    .toURL().toString();
 
     Map<String, XMLizable> cache = resMgr.getImportCache();
     assertThat(cache).containsOnlyKeys(typeSystemImportedByLocation, typeSystemImportedByName,

--- a/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/resource/metadata/impl/TypeSystemDescription_implTest.java
@@ -158,9 +158,11 @@ public class TypeSystemDescription_implTest {
     String typeSystemImportedFromDataPath = new File(
             "target/test-classes/TypeSystemDescriptionImplTest/dataPathDir/TypeSystemImportedFromDataPath.xml")
                     .toURL().toString();
+    // FIXME: REC 2023-02-17 - At some point we should investigate why on this one we need to use
+    // toURI().toURL() and on the others just toURL()....
     String typeSystemImportedByName = new File(
             "target/test-classes/org/apache/uima/resource/metadata/impl/TypeSystemImportedByName.xml")
-                    .toURL().toString();
+                    .toURI().toURL().toString();
 
     Map<String, XMLizable> cache = resMgr.getImportCache();
     assertThat(cache).containsOnlyKeys(typeSystemImportedByLocation, typeSystemImportedByName,


### PR DESCRIPTION
**What's in the PR**
- Try using deprecated non-escaping toURL() because it seems that  might be what the tested code is using internally as well

**How to test manually**
* Try running the test on Windows

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
