### PR TITLE
Issue #320: Copy of FsIterator_set_sorted_pear does not retain position

### DIFF
--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -129,6 +129,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIterator_set_sorted2.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIterator_set_sorted2.java
@@ -177,8 +177,12 @@ class FsIterator_set_sorted2<T extends FeatureStructure> extends FsIterator_sing
   public FsIterator_singletype<T> copy() {
     FsIterator_set_sorted2<T> r = new FsIterator_set_sorted2<>(ll_index, ofsa,
             comparatorMaybeNoTypeWithoutID);
-    r.pos = pos;
+    copyCommonSetup(r);
     return r;
+  }
+
+  protected void copyCommonSetup(FsIterator_set_sorted2<T> copy) {
+    copy.pos = pos;
   }
 
   // /* (non-Javadoc)

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIterator_set_sorted_pear.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/FsIterator_set_sorted_pear.java
@@ -47,6 +47,9 @@ class FsIterator_set_sorted_pear<T extends FeatureStructure> extends FsIterator_
 
   @Override
   public FsIterator_set_sorted_pear<T> copy() {
-    return new FsIterator_set_sorted_pear<>(ll_index, ofsa, this.comparatorMaybeNoTypeWithoutID);
+    FsIterator_set_sorted_pear<T> r = new FsIterator_set_sorted_pear<>(ll_index, ofsa,
+            this.comparatorMaybeNoTypeWithoutID);
+    copyCommonSetup(r);
+    return r;
   }
 }

--- a/uimaj-core/src/test/java/org/apache/uima/cas/impl/FsIterator_set_sorted_pearTest.java
+++ b/uimaj-core/src/test/java/org/apache/uima/cas/impl/FsIterator_set_sorted_pearTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.cas.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Comparator;
+
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.internal.util.CopyOnWriteOrderedFsSet_array;
+import org.apache.uima.jcas.cas.TOP;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FsIterator_set_sorted_pearTest {
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  void thatCopyRetainsPosition() throws Exception {
+    FsIndex_set_sorted<FeatureStructure> ll_index = Mockito.mock(FsIndex_set_sorted.class);
+    CopyOnWriteIndexPart cow_wrapper = Mockito.mock(CopyOnWriteOrderedFsSet_array.class);
+    Comparator<TOP> comparatorMaybeNoTypeWithoutID = Mockito.mock(Comparator.class);
+
+    FsIterator_set_sorted_pear<FeatureStructure> sut = Mockito.spy(new FsIterator_set_sorted_pear<>(
+            ll_index, cow_wrapper, comparatorMaybeNoTypeWithoutID));
+    sut.pos = 1;
+    FsIterator_set_sorted_pear<FeatureStructure> sutCopy = sut.copy();
+    assertThat(sutCopy.pos).isEqualTo(sut.pos);
+  }
+}

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -145,6 +145,7 @@
     <commons-csv-version>1.10.0</commons-csv-version>
     <jackson-version>2.15.2</jackson-version>
     <junit-version>5.9.3</junit-version>
+    <mockito-version>4.11.0</mockito-version>
     <assertj-version>3.24.2</assertj-version>
     <xmlunit-version>2.9.1</xmlunit-version>
     <maven.version>3.2.5</maven.version>
@@ -166,24 +167,18 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-version}</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>${mockito-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
         <version>${junit-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
**What's in the PR**
- Fix issue in FsIterator_set_sorted_pear
- Added unit test

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [x] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
  * Adds Mockito as a test dependency. Mockito has MIT license. No need to update notice files since as a test dependency, we do not package it with releases.