### PR TITLE
Issue #325 - Update dependencies

### DIFF
--- a/jcasgen-maven-plugin/pom.xml
+++ b/jcasgen-maven-plugin/pom.xml
@@ -16,7 +16,9 @@
 	specific language governing permissions and limitations
 	under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.uima</groupId>
@@ -24,17 +26,20 @@
     <version>3.5.0-SNAPSHOT</version>
     <relativePath>../uimaj-parent/pom.xml</relativePath>
   </parent>
-  
-  <!-- This artifact name follows the conventions described http://books.sonatype.com/mvnref-book/reference/writing-plugins-sect-custom-plugin.html
-       where patterns like xxx-maven-plugin and maven-xxx-plugin can be invoked just using xxx if the right settings are in place -->
+
+  <!-- This artifact name follows the conventions described
+  http://books.sonatype.com/mvnref-book/reference/writing-plugins-sect-custom-plugin.html
+       where patterns like xxx-maven-plugin and maven-xxx-plugin can be invoked just
+  using xxx if the right settings are in place -->
   <artifactId>jcasgen-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
 
   <name>Apache UIMA Maven: ${project.artifactId}</name>
-  <description>A Maven Plugin for using JCasGen to generate Java classes from XML type system descriptions</description>
+  <description>A Maven Plugin for using JCasGen to generate Java classes from
+    XML type system descriptions</description>
 
   <prerequisites>
-    <maven>3.0</maven>
+    <maven>${maven.version}</maven>
   </prerequisites>
 
   <dependencies>
@@ -84,23 +89,26 @@
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-build-api</artifactId>
-      <version>0.0.7</version>
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -120,7 +128,7 @@
               <tagletArtifact>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-tools-javadoc</artifactId>
-                <version>2.9</version>
+                <version>3.5.2</version>
               </tagletArtifact>
             </tagletArtifacts>
           </configuration>
@@ -145,7 +153,8 @@
             <goal>package</goal>
             <goal>integration-test</goal>
           </goals>
-          <!-- change this next line by toggling the "!" character to include / exclude the long-running m2e test
+          <!-- change this next line by toggling the "!" character to include /
+          exclude the long-running m2e test
                It is normally excluded -->
           <invokerTest>classpath,multimodule,simple,!m2e</invokerTest>
         </configuration>

--- a/jcasgen-maven-plugin/src/test/java/org/apache/uima/tools/jcasgen/maven/JCasGenMojoTest.java
+++ b/jcasgen-maven-plugin/src/test/java/org/apache/uima/tools/jcasgen/maven/JCasGenMojoTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.uima.tools.jcasgen.maven;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +30,10 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Assert;
+import org.eclipse.aether.RepositorySystemSession;
 import org.junit.Test;
 
 public class JCasGenMojoTest extends AbstractMojoTestCase {
@@ -83,8 +86,10 @@ public class JCasGenMojoTest extends AbstractMojoTestCase {
     assertTrue(pomFile.exists());
 
     // create the MavenProject from the pom.xml file
+    RepositorySystemSession session = MavenRepositorySystemUtils.newSession();
     MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
     ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();
+    buildingRequest.setRepositorySession(session);
     ProjectBuilder projectBuilder = this.lookup(ProjectBuilder.class);
     MavenProject project = projectBuilder.build(pomFile, buildingRequest).getProject();
     assertNotNull(project);
@@ -123,7 +128,7 @@ public class JCasGenMojoTest extends AbstractMojoTestCase {
       // no _type files in v3
       // File typeFile = new File(jCasGenDirectory + "/" + type.replace('.', '/') + "_Type.java");
 
-      Assert.assertTrue(files.contains(wrapperFile));
+      assertThat(files).contains(wrapperFile);
       // no _type files in v3
       // Assert.assertTrue(files.contains(typeFile));
 
@@ -132,9 +137,9 @@ public class JCasGenMojoTest extends AbstractMojoTestCase {
     }
 
     // check that no extra files were generated
-    Assert.assertTrue(files.isEmpty());
+    assertThat(files).isEmpty();
 
     // check that the generated sources are on the compile path
-    Assert.assertTrue(project.getCompileSourceRoots().contains(jCasGenDirectory.getAbsolutePath()));
+    assertThat(project.getCompileSourceRoots()).contains(jCasGenDirectory.getAbsolutePath());
   }
 }

--- a/uimaj-adapter-vinci/pom.xml
+++ b/uimaj-adapter-vinci/pom.xml
@@ -55,7 +55,7 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/uimaj-component-test-util/pom.xml
+++ b/uimaj-component-test-util/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/uimaj-ep-cas-editor-ide/pom.xml
+++ b/uimaj-ep-cas-editor-ide/pom.xml
@@ -113,7 +113,7 @@
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/uimaj-ep-cas-editor/pom.xml
+++ b/uimaj-ep-cas-editor/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -145,6 +145,7 @@
     <commons-csv-version>1.10.0</commons-csv-version>
     <jackson-version>2.15.2</jackson-version>
     <junit-version>5.9.3</junit-version>
+    <junit-vintage-version>4.13.2</junit-vintage-version>
     <mockito-version>4.11.0</mockito-version>
     <assertj-version>3.24.2</assertj-version>
     <xmlunit-version>2.9.1</xmlunit-version>
@@ -179,6 +180,11 @@
         <version>${junit-version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit-vintage-version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -237,6 +243,31 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.sonatype.plexus</groupId>
+        <artifactId>plexus-build-api</artifactId>
+        <version>0.0.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugin-testing</groupId>
+        <artifactId>maven-plugin-testing-harness</artifactId>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-core</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-compat</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -255,10 +286,20 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <!-- Can be removed after updating to the UIMA Parent POM 16 or higher  -->
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.4</version>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-engine</artifactId>
+              <version>${junit-version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.vintage</groupId>
+              <artifactId>junit-vintage-engine</artifactId>
+              <version>${junit-version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -155,8 +155,9 @@
     <asciidoctor.version>2.5.10</asciidoctor.version>
     <asciidoctor.pdf.version>2.3.9</asciidoctor.pdf.version>
 
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
 
     <eclipseP2RepoId>org.eclipse.p2.201812</eclipseP2RepoId>
 

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -144,7 +144,7 @@
     <commons-io-version>2.13.0</commons-io-version>
     <commons-csv-version>1.10.0</commons-csv-version>
     <jackson-version>2.15.2</jackson-version>
-    <junit-version>5.9.3</junit-version>
+    <junit-version>5.10.0</junit-version>
     <junit-vintage-version>4.13.2</junit-vintage-version>
     <mockito-version>4.11.0</mockito-version>
     <assertj-version>3.24.2</assertj-version>
@@ -152,8 +152,8 @@
     <maven.version>3.2.5</maven.version>
 
     <asciidoctor.plugin.version>2.2.4</asciidoctor.plugin.version>
-    <asciidoctor.version>2.5.8</asciidoctor.version>
-    <asciidoctor.pdf.version>2.3.7</asciidoctor.pdf.version>
+    <asciidoctor.version>2.5.10</asciidoctor.version>
+    <asciidoctor.pdf.version>2.3.9</asciidoctor.pdf.version>
 
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -341,15 +341,6 @@
             </ignoreMissingClassesByRegularExpressions>
           </parameter>
         </configuration>
-        <dependencies>
-          <dependency>
-            <!-- See: https://issues.apache.org/jira/browse/UIMA-6349 -->
-            <!-- Can be removed after updating to the UIMA Parent POM 16 or higher  -->
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-jsr223</artifactId>
-            <version>2.5.17</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>

--- a/uimaj-test-util/pom.xml
+++ b/uimaj-test-util/pom.xml
@@ -40,7 +40,7 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>compile</scope>  <!-- is normally test scope, so need to be explicit -->
     </dependency>
     <dependency>
@@ -51,12 +51,10 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>${xmlunit-version}</version>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-assertj3</artifactId>
-      <version>${xmlunit-version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
**What's in the PR**
- junit4 -> 4.13.2 (needed for Maven plugin test harness...)
- maven-plugin-testing-harness 2.0 -> 3.3.0
- maven-plugin-tools-javadoc 2.9 -> 3.5.2
- maven-compat -> 3.2.5
- junit5 5.9.3 -> 5.10.0
- asciidoctor 2.5.8 -> 2.5.10
- asciidoctor-pdf 2.3.7 -> 2.3.9
- Removed redundant plugin dependency override
- Depend on junit-jupiter-api instead of junit-jupiter-engine for unit tests

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
