### PR TITLE
Issue #337: Component description editor may not open in Eclipse

### DIFF
--- a/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/editors/MultiPageEditorContributor.java
+++ b/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/editors/MultiPageEditorContributor.java
@@ -23,11 +23,11 @@ import org.apache.uima.taeconfigurator.Messages;
 import org.apache.uima.taeconfigurator.PreferencePage;
 import org.apache.uima.taeconfigurator.TAEConfiguratorPlugin;
 import org.apache.uima.taeconfigurator.editors.xml.XMLEditor;
-import org.eclipse.core.runtime.Preferences;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchActionConstants;
@@ -109,8 +109,9 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
    */
   @Override
   public void setActiveEditor(IEditorPart part) {
-    if (activeEditorPart == part)
+    if (activeEditorPart == part) {
       return;
+    }
 
     if (null == part) {
       return;
@@ -190,9 +191,9 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
       // to update the checked status to correspond to that
       @Override
       public void run() {
-        TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-        Preferences prefs = plugin.getPluginPreferences();
+        IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
         boolean bAutoJCasGen = !prefs.getBoolean(PreferencePage.P_JCAS);
+
         autoJCasAction.setChecked(bAutoJCasGen);
         prefs.setValue(PreferencePage.P_JCAS, bAutoJCasGen);
       }
@@ -203,8 +204,7 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
       // to update the checked status to correspond to that
       @Override
       public void run() {
-        TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-        Preferences prefs = plugin.getPluginPreferences();
+        IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
         boolean bJCasLimit = !prefs.getBoolean(PreferencePage.P_JCAS_LIMIT_TO_PROJECT_SCOPE);
         limitJCasGenToProject.setChecked(bJCasLimit);
         prefs.setValue(PreferencePage.P_JCAS_LIMIT_TO_PROJECT_SCOPE, bJCasLimit);
@@ -222,8 +222,7 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
     qualifiedTypesAction = new Action() {
       @Override
       public void run() {
-        TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-        Preferences prefs = plugin.getPluginPreferences();
+        IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
         boolean bFullyQualifiedTypeNames = !prefs
                 .getBoolean(PreferencePage.P_SHOW_FULLY_QUALIFIED_NAMES);
         qualifiedTypesAction.setChecked(bFullyQualifiedTypeNames);
@@ -373,8 +372,7 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
    * @return the uima pref string
    */
   private static String getUimaPrefString(String key, String defaultValue) {
-    TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-    Preferences prefs = plugin.getPluginPreferences();
+    IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
     boolean isDefault = prefs.isDefault(key);
     if (isDefault) {
       prefs.setDefault(key, defaultValue);
@@ -392,8 +390,7 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
    * @return the uima pref boolean
    */
   private static boolean getUimaPrefBoolean(String key, boolean defaultValue) {
-    TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-    Preferences prefs = plugin.getPluginPreferences();
+    IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
     boolean isDefault = prefs.isDefault(key);
     if (isDefault) {
       prefs.setDefault(key, defaultValue);
@@ -411,8 +408,7 @@ public class MultiPageEditorContributor extends MultiPageEditorActionBarContribu
    * @return the uima pref int
    */
   private static int getUimaPrefInt(String key, int defaultValue) {
-    TAEConfiguratorPlugin plugin = TAEConfiguratorPlugin.getDefault();
-    Preferences prefs = plugin.getPluginPreferences();
+    IPreferenceStore prefs = TAEConfiguratorPlugin.getDefault().getPreferenceStore();
     boolean isDefault = prefs.isDefault(key);
     if (isDefault) {
       prefs.setDefault(key, defaultValue);

--- a/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/files/ContextForPartDialog.java
+++ b/uimaj-ep-configurator/src/main/java/org/apache/uima/taeconfigurator/files/ContextForPartDialog.java
@@ -160,8 +160,9 @@ public class ContextForPartDialog extends /* LimitedResourceSelectionDialog */
     super.handleEvent(event);
 
     if (event.widget == resourcesUI && event.type == SWT.Selection) {
-      if (null != pickedResource) {
-        IFile f = (IFile) getResult()[0];
+      Object[] result = getResult();
+      if (null != pickedResource && result != null && result.length > 0) {
+        IFile f = (IFile) result[0];
         contextPathGUI.setText(f.getLocation().toOSString());
       }
     }
@@ -187,8 +188,9 @@ public class ContextForPartDialog extends /* LimitedResourceSelectionDialog */
   public void enableOK() {
     super.enableOK();
     String path = contextPathGUI.getText();
-    if (null != path && !"".equals(path))
+    if (null != path && !"".equals(path)) {
       okButton.setEnabled(true);
+    }
   }
 
   /*


### PR DESCRIPTION
**What's in the PR**
- Upgrade to IPreferenceStore and non-deprecated API (at least non-deprecated in the venerable Eclipse version we build against)

**How to test manually**
* Build Eclipse plugins
* Install into a vanilla Eclipse 20230-06

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
