### PR TITLE
INFRA-24767: Connection reset when accessing Maven Central on Jenkins Windows Build Nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('uima-build-jenkins-shared-library') _
+@Library('uima-build-jenkins-shared-library@bugfix/INFRA-24767-Connection-reset-when-accessing-Maven-Central-on-Jenkins-Windows-Build-Nodes') _
 
 defaultPipeline {
   // extraMavenArguments = '-Pjacoco,spotbugs,pmd,run-rat-report -Ddisable-rc-auto-staging'


### PR DESCRIPTION
**What's in the PR**
- Pin build to particular Windows node

**How to test manually**
* Let Jenkins run the build

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
