### PR TITLE
Issue #371: Repeated creation of type systems can exhaust JVM metaspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ api-change-report
 issuesFixed
 .idea
 *.iml
+.tycho-consumer-pom.xml

--- a/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/impl/TypeSystemImpl.java
@@ -1477,7 +1477,7 @@ public class TypeSystemImpl implements TypeSystem, TypeSystemMgr, LowLevelTypeSy
     // }
     // }
 
-    type2jcci = FSClassRegistry.get_className_to_jcci(cl, false); // is not pear
+    type2jcci = FSClassRegistry.get_className_to_jcci(cl, false /* is not PEAR */);
     lookup = FSClassRegistry.getLookup(cl);
     cl_for_commit = cl;
 

--- a/uimaj-core/src/main/java/org/apache/uima/internal/util/UIMAClassLoader.java
+++ b/uimaj-core/src/main/java/org/apache/uima/internal/util/UIMAClassLoader.java
@@ -45,6 +45,7 @@ import org.apache.uima.cas.impl.TypeSystemImpl;
  * 
  */
 public class UIMAClassLoader extends URLClassLoader {
+  private static final URL[] NO_URLS = new URL[0];
 
   static {
     if (!ClassLoader.registerAsParallelCapable()) {
@@ -143,6 +144,17 @@ public class UIMAClassLoader extends URLClassLoader {
    */
   public UIMAClassLoader(URL[] classpath) {
     super(classpath);
+    commonInit();
+  }
+
+  /**
+   * Creates a new UIMAClassLoader with the given parent ClassLoader.
+   * 
+   * @param parent
+   *          specify the parent of the classloader
+   */
+  public UIMAClassLoader(ClassLoader parent) {
+    super(NO_URLS, parent);
     commonInit();
   }
 

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -444,6 +444,19 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <tags combine.children="append">
+              <tag>
+                <name>forRemoval</name>
+                <placement>a</placement>
+                <head>To be removed in version:</head>
+              </tag>
+            </tags>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
**What's in the PR**
- Added test case to check for the leak
- Changed code to always use the lookup from the classloader associated with the JCas wrapper class and deprecated methods (parameters) that passed though the lookup from elsewhere
- Changed to cache generators per JCas wrapper class to avoid one hidden classes being generated for the same generator repeatedly (since these are no longer garbage collected by current JREs)

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
