### PR TITLE
No issue: Unrequire status checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,10 +44,10 @@ github:
     main:
      required_status_checks:
         strict: true
-        contexts:
-          - continuous-integration/jenkins/pr-merge
+#        contexts:
+#          - continuous-integration/jenkins/pr-merge
     main-v2:
      required_status_checks:
         strict: true
-        contexts:
-          - continuous-integration/jenkins/pr-merge
+#        contexts:
+#          - continuous-integration/jenkins/pr-merge


### PR DESCRIPTION
**What's in the PR**
- Since we cannot configure the repo to allow merging without status checks for admins (because we are not project admins), I un-require the status checks to allow merging the bugfix branch into the release branch without having to set up a PR first.

**How to test manually**
* No specific test procecure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
