### PR TITLE
Issue #385: Allow import of type systems published through SPI

### DIFF
--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -110,11 +110,12 @@
               org.apache.uima.fit.*
             </Export-Package>
             <Require-Capability>
-            	osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
-            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional,
-            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypePrioritiesProvider)";cardinality:=multiple;resolution:=optional,
-            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional,
-            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.fit.validation.ValidationCheck)";cardinality:=multiple;resolution:=optional
+              osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypePrioritiesProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.fit.validation.ValidationCheck)";cardinality:=multiple;resolution:=optional
             </Require-Capability>
           </instructions>
         </configuration>

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
@@ -336,19 +336,15 @@ public final class FsIndexFactory {
     var loaded = Collections.newSetFromMap(new IdentityHashMap<>());
 
     ServiceLoader.load(FsIndexCollectionProvider.class).forEach(provider -> {
-      loaded.add(provider);
       for (var fsIdxCol : provider.listFsIndexCollections()) {
         loaded.add(fsIdxCol);
         fsIndexList.addAll(asList(fsIdxCol.getFsIndexes()));
-        LOG.debug("Loaded SPI-provided index collection at [{}]", fsIdxCol.getSourceUrlString());
+        LOG.debug("Loaded legacy SPI-provided index collection at [{}]",
+                fsIdxCol.getSourceUrlString());
       }
     });
 
     ServiceLoader.load(TypeSystemProvider.class).forEach(provider -> {
-      if (loaded.contains(provider)) {
-        return;
-      }
-
       for (var fsIdxCol : provider.listFsIndexCollections()) {
         if (loaded.contains(fsIdxCol)) {
           continue;

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -171,20 +171,14 @@ public final class TypePrioritiesFactory {
     var loaded = Collections.newSetFromMap(new IdentityHashMap<>());
 
     ServiceLoader.load(TypePrioritiesProvider.class).forEach(provider -> {
-      loaded.add(provider);
-
       for (var desc : provider.listTypePriorities()) {
         loaded.add(desc);
         typePrioritiesList.add(desc);
-        LOG.debug("Loaded SPI-provided type priorities at [{}]", desc.getSourceUrlString());
+        LOG.debug("Loaded legacy SPI-provided type priorities at [{}]", desc.getSourceUrlString());
       }
     });
 
     ServiceLoader.load(TypeSystemProvider.class).forEach(provider -> {
-      if (loaded.contains(provider)) {
-        return;
-      }
-
       for (var desc : provider.listTypePriorities()) {
         if (loaded.contains(desc)) {
           continue;

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
@@ -174,19 +174,14 @@ public final class TypeSystemDescriptionFactory {
     var loaded = Collections.newSetFromMap(new IdentityHashMap<>());
 
     ServiceLoader.load(TypeSystemDescriptionProvider.class).forEach(provider -> {
-      loaded.add(provider);
       for (var desc : provider.listTypeSystemDescriptions()) {
         loaded.add(desc);
         tsdList.add(desc);
-        LOG.debug("Loaded SPI-provided type system at [{}]", desc.getSourceUrlString());
+        LOG.debug("Loaded legacy SPI-provided type system at [{}]", desc.getSourceUrlString());
       }
     });
 
     ServiceLoader.load(TypeSystemProvider.class).forEach(provider -> {
-      if (loaded.contains(provider)) {
-        return;
-      }
-
       for (var desc : provider.listTypeSystemDescriptions()) {
         if (loaded.contains(desc)) {
           continue;

--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -213,6 +213,7 @@
             <Require-Capability>
               osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.JCasClassProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemProvider)";cardinality:=multiple;resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypePrioritiesProvider)";cardinality:=multiple;resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional


### PR DESCRIPTION
**What's in the PR**
- Added capabilities for the new unified provider
- Checking if a provider has already been processed when scanning legacy and new providers does not help because they are instantiated freshly on every call to the service provider scanner, so remove that
- Log different messages when loading through the legacy SPI interfaces and through the new one

**How to test manually**
* Try using the new unified SPI

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
