### PR TITLE
Issue #422: Exclude release-related marker files from source distributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,6 @@
 #   The internal repo form for these is always lf, 
 #   The eol=lf means on check-out do nothing, and on check-in, if the file has crlf, convert to lf
 *.sh text eol=lf
+
+marker-file-enabling-auto-staging export-ignore
+marker-file-enabling-release-notes export-ignore

--- a/src/main/assembly/src.xml
+++ b/src/main/assembly/src.xml
@@ -79,6 +79,13 @@ under the License.
         <exclude>**/checkpoint_synchPoint.xml.prev</exclude>
 
         <!-- 
+          - Marker files enabling release-supporting profiles that expect a git repository and/or svn to be available
+          - and are therefore not suitable for use when building from the source archive.
+          -->
+        <exclude>**/marker-file-enabling-auto-staging</exclude>
+        <exclude>**/marker-file-enabling-release-notes</exclude>
+
+        <!-- 
           File that seems to be temporarily placed into the CWD during the build but no idea where 
           it comes from. 
         -->


### PR DESCRIPTION
**What's in the PR**
- Exclude release profile marker files from release source ZIP
- Exclude release profile marker files from GitHub ZIP

**How to test manually**
* Try building from the source ZIP

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
