### PR TITLE
Issue #431: Issue using SPI-enabled type systems embedded into PEARs

### DIFF
--- a/uimaj-core/pom.xml
+++ b/uimaj-core/pom.xml
@@ -216,7 +216,8 @@
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemProvider)";cardinality:=multiple;resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional,
               osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypePrioritiesProvider)";cardinality:=multiple;resolution:=optional,
-              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional,
+              osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.fit.validation.ValidationCheck)";cardinality:=multiple;resolution:=optional
             </Require-Capability>
           </instructions>
         </configuration>

--- a/uimaj-core/src/main/java/org/apache/uima/cas/SerialFormat.java
+++ b/uimaj-core/src/main/java/org/apache/uima/cas/SerialFormat.java
@@ -29,12 +29,12 @@ public enum SerialFormat {
   UNKNOWN(""),
 
   /**
-   * XML-serialized CAS
+   * XML-serialized CAS, using XML version 1.0
    */
   XCAS("xcas"),
 
   /**
-   * XML-serialized CAS
+   * XML-serialized CAS, using XML version 1.0
    */
   XMI("xmi"),
 
@@ -64,7 +64,7 @@ public enum SerialFormat {
   SERIALIZED("scas"),
 
   /**
-   * Java-serialized CAS with type system and index definitions The Typs System and Index Definition
+   * Java-serialized CAS with type system and index definitions The Type System and Index Definition
    * replaces the CAS's when deserializing.
    */
   SERIALIZED_TSI("scas"),
@@ -95,22 +95,22 @@ public enum SerialFormat {
   COMPRESSED_TSI("bcas"),
 
   /**
-   * XML-serialized CAS, using xml version 1.1
+   * XML-serialized CAS, using XML version 1.1
    */
   XCAS_1_1("xcas"),
 
   /**
-   * XML-serialized CAS, using xml version 1.1
+   * XML-serialized CAS, using XML version 1.1
    */
   XMI_1_1("xmi"),
 
   /**
-   * XML-serialized CAS, using xml version 1.1 - pretty-printed
+   * XML-serialized CAS, using XML version 1.0 - pretty-printed
    */
   XMI_PRETTY("xmi"),
 
   /**
-   * XML-serialized CAS, using xml version 1.1 - pretty-printed
+   * XML-serialized CAS, using XML version 1.1 - pretty-printed
    */
   XMI_1_1_PRETTY("xmi"),;
 


### PR DESCRIPTION
**What's in the PR**
- uimaFIT will now use the UIMA Framework classloader to discover ValidationChecks, so the uimaj-core bundle needs to declare that SPI in its OSGi metadata
- Fix copy/paste issue in SerialFormat JavaDoc

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
