### PR TITLE
Issue #438: Upgrade dependencies (3.6.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>11.1.0</version>
+            <version>12.1.5</version>
             <executions>
               <execution>
                <goals><goal>check</goal></goals>

--- a/src/main/assembly/bin-without-jackson.xml
+++ b/src/main/assembly/bin-without-jackson.xml
@@ -210,7 +210,7 @@ under the License.
         <include>org.springframework:spring-context</include>
         <include>org.springframework:spring-core</include>
         <include>org.springframework:spring-expression</include>
-        <include>org.springframework:spring-jcl/5.3.39/spring-jcl-5.3.39.jar</include>
+        <include>org.springframework:spring-jcl</include>
       </includes>
       <unpack>false</unpack>
       <scope>runtime</scope>

--- a/src/main/bin_distr_license_notices/LICENSE.txt
+++ b/src/main/bin_distr_license_notices/LICENSE.txt
@@ -267,9 +267,9 @@ Copyright (c) 2004-2017 QOS.ch
 
 =======================================================================
 
-SPRING FRAMEWORK 6.1.15 SUBCOMPONENTS:
+SPRING FRAMEWORK 6.2.11 SUBCOMPONENTS:
 
-Spring Framework 6.1.15 includes a number of subcomponents
+Spring Framework 6.2.11 includes a number of subcomponents
 with separate copyright notices and license terms. The product that
 includes this file does not necessarily use all the open source
 subcomponents referred to below. Your use of the source

--- a/src/main/bin_distr_license_notices/NOTICE-without-jackson.md
+++ b/src/main/bin_distr_license_notices/NOTICE-without-jackson.md
@@ -17,16 +17,16 @@ ResolverUtil.java Copyright 2005-2006 Tim Fennell
 # Apache Commons IO
 
 Apache Commons IO
-Copyright 2002-2024 The Apache Software Foundation
+Copyright 2002-2025 The Apache Software Foundation
 
 # Apache Commons Lang
 
 Apache Commons Lang
-Copyright 2001-2024 The Apache Software Foundation
+Copyright 2001-2025 The Apache Software Foundation
 
 # Spring Framework
 
-Copyright (c) 2002-2024 Pivotal, Inc.
+Copyright (c) 2002-2025 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/src/main/bin_distr_license_notices/NOTICE.md
+++ b/src/main/bin_distr_license_notices/NOTICE.md
@@ -17,14 +17,14 @@ ResolverUtil.java Copyright 2005-2006 Tim Fennell
 # Apache Commons IO
 
 Apache Commons IO
-Copyright 2002-2024 The Apache Software Foundation
+Copyright 2002-2025 The Apache Software Foundation
 
 # Apache Commons Lang
 
 Apache Commons Lang
-Copyright 2001-2024 The Apache Software Foundation
+Copyright 2001-2025 The Apache Software Foundation
 
-# Jackson JSON processor NOTICE from the Jackson Jar 2.15.2
+# Jackson JSON processor NOTICE from the Jackson Jar 2.20.0
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
@@ -59,7 +59,7 @@ and the licenses and copyrights that apply to that code.
 
 # Spring Framework
 
-Copyright (c) 2002-2024 Pivotal, Inc.
+Copyright (c) 2002-2025 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/uimafit-maven-plugin/pom.xml
+++ b/uimafit-maven-plugin/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.2.0-jre</version>
+      <version>33.5.0-jre</version>
     </dependency>
   </dependencies>
 

--- a/uimaj-parent-internal/pom.xml
+++ b/uimaj-parent-internal/pom.xml
@@ -56,30 +56,30 @@
     
     <maven.version>3.8.1</maven.version>
 
-    <asciidoctor.plugin.version>3.1.1</asciidoctor.plugin.version>
+    <asciidoctor.plugin.version>3.2.0</asciidoctor.plugin.version>
     <asciidoctor.version>3.0.0</asciidoctor.version>
     <asciidoctor.pdf.version>2.3.19</asciidoctor.pdf.version>
-    <assertj-version>3.26.3</assertj-version>
-    <bnd-version>7.0.0</bnd-version>
-    <bytebuddy-version>1.15.10</bytebuddy-version>
-    <commons-csv-version>1.12.0</commons-csv-version>
-    <commons-collections4-version>4.4</commons-collections4-version>
-    <commons-io-version>2.18.0</commons-io-version>
-    <commons-lang3-version>3.17.0</commons-lang3-version>
+    <assertj-version>3.27.5</assertj-version>
+    <bnd-version>7.1.0</bnd-version>
+    <bytebuddy-version>1.17.7</bytebuddy-version>
+    <commons-csv-version>1.14.1</commons-csv-version>
+    <commons-collections4-version>4.5.0</commons-collections4-version>
+    <commons-io-version>2.20.0</commons-io-version>
+    <commons-lang3-version>3.18.0</commons-lang3-version>
     <commons-math3-version>3.6.1</commons-math3-version>
-    <jackson-version>2.18.1</jackson-version>
+    <jackson-version>2.20.0</jackson-version>
     <javassist-version>3.30.2-GA</javassist-version>
-    <junit-version>5.11.3</junit-version>
-    <junit-platform-version>1.11.3</junit-platform-version>
+    <junit-version>5.11.4</junit-version>
+    <junit-platform-version>1.11.4</junit-platform-version>
     <junit-vintage-version>4.13.2</junit-vintage-version>
-    <log4j-version>2.24.1</log4j-version>
-    <mockito-version>5.14.2</mockito-version>
+    <log4j-version>2.25.2</log4j-version>
+    <mockito-version>5.18.0</mockito-version>
     <opentest4j-version>1.3.0</opentest4j-version>
     <qdox-version>2.1.0</qdox-version>
     <slf4j-version>1.7.36</slf4j-version>
-    <spring-version>6.1.15</spring-version>
-    <tycho-version>4.0.10</tycho-version>
-    <xmlunit-version>2.10.0</xmlunit-version>
+    <spring-version>6.2.11</spring-version>
+    <tycho-version>4.0.13</tycho-version>
+    <xmlunit-version>2.10.4</xmlunit-version>
 
     <eclipseP2RepoId>org.eclipse.p2.202209</eclipseP2RepoId>
 


### PR DESCRIPTION
**What's in the PR**
- asciidoctor 3.1.1 -> 3.2.0
- assertj 3.26.3 -> 3.27.5
- bnd 7.0.0 -> 7.1.0
- bytebuddy 1.15.10 -> 1.17.7
- commons-csv 1.12.0 -> 1.14.1
- commons-collections4 4.4 -> 4.5.0
- commons-io 2.18.0 -> 2.20.0
- commons-lang3 3.17.0 -> 3.18.0
- junit 5.11.3 -> 5.11.4
- junit-platform 1.11.3 -> 1.11.4
- mockito 5.14.2 -> 5.18.0
- spring 6.1.15 -> 6.2.11
- tycho 4.0.10 -> 4.0.13
- xmlunit 2.10.0 -> 2.10.4
- guava 33.2.0 -> 33.5.0
- dependency-check-maven 11.1.0 -> 12.1.5

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [x] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
