### PR TITLE
#459 - Builds inheriting uimaj-parent fail under Maven 4 due to uninterpolated eclipseP2RepoId in repository id

### DIFF
--- a/uimaj-parent-internal/pom.xml
+++ b/uimaj-parent-internal/pom.xml
@@ -484,6 +484,14 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <repository>
+      <id>${eclipseP2RepoId}</id>
+      <url>https://download.eclipse.org/releases/2023-06/</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>19-SNAPSHOT</version>
+    <version>19</version>
     <relativePath />
   </parent>
 

--- a/uimaj-parent/pom.xml
+++ b/uimaj-parent/pom.xml
@@ -99,11 +99,6 @@
     </repository>
     -->
 
-    <repository>
-      <id>${eclipseP2RepoId}</id>
-      <url>https://download.eclipse.org/releases/2023-06/</url>
-      <layout>p2</layout>
-    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
**What's in the PR**
- Move Eclipse P2 repository declaration from published uimaj-parent to internal uimaj-parent-internal to fix Maven 4 build failures in downstream projects

**How to test manually**
* See issue description - check that project still builds

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
