### PR TITLE
Issue #440: Upgrade dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,25 +39,23 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.head_ref || github.ref }}
 
     - name: Set up JDK ${{ matrix.jdk }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'temurin'
         cache: maven
 
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
-      with:
-        maven-version: 3.9.9
+    # No explicit Maven setup: the GitHub-hosted runner images ship Maven
+    # 3.9.16, which is newer than the version we used to install here.
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -75,6 +73,6 @@ jobs:
       run: mvn --no-transfer-progress -B --settings .github/maven-settings.xml -DskipTests clean verify --file pom.xml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.head_ref || github.ref }}
 
     - name: Set up JDK ${{ matrix.jdk }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'temurin'
@@ -41,10 +41,8 @@ jobs:
         server-username: NEXUS_USERNAME
         server-password: NEXUS_PASSWORD
 
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
-      with:
-        maven-version: 3.9.9
+    # No explicit Maven setup: the GitHub-hosted runner images ship Maven
+    # 3.9.16, which is newer than the version we used to install here.
 
     - name: Set up cache date
       run: echo "CACHE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
@@ -54,7 +52,7 @@ jobs:
       run: mvn --show-version --batch-mode --no-transfer-progress --settings .github/maven-settings.xml clean verify
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.mvn/versions-rules.xml
+++ b/.mvn/versions-rules.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Ruleset for versions-maven-plugin, used to filter out pre-release and
+  variant artifacts when looking for dependency/plugin upgrades.
+
+  NOTE: This file is deliberately NOT referenced via <rulesUri> from any POM.
+
+  uimaj-parent is a pure parent POM published to Maven Central for downstream
+  projects to inherit from. Anything placed in its <pluginManagement> becomes
+  part of the contract inherited by every consumer. A <rulesUri> using
+  ${maven.multiModuleProjectDirectory} would resolve against the *consuming*
+  project's directory, pointing at a file that does not exist there and
+  breaking their versions:* goals. An absolute path or file: URL would just
+  move the breakage to machines that lack the file.
+
+  So pass it on the command line instead:
+
+    mvn -Dmaven.version.rules=file://$(pwd)/.mvn/versions-rules.xml \
+        versions:display-dependency-updates -DallowMajorUpdates=true
+
+  (The user property is `maven.version.rules`, not `rulesUri`.)
+-->
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0">
+  <ignoreVersions>
+    <!-- Pre-release suffixes - these are not "updates" -->
+    <ignoreVersion type="regex">(?i).*[-_\.]CR[0-9\.]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]M[0-9\.]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]rc[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]Dev[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]alpha[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]beta[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]preview[0-9\.-]*</ignoreVersion>
+    <!-- Date-stamped variants (e.g. ...20040117.000000) -->
+    <ignoreVersion type="regex">\d{4,}.*</ignoreVersion>
+    <!-- Backwards-compat variants for legacy JDKs (e.g. byte-buddy 1.18.8-jdk5) -->
+    <ignoreVersion type="regex">(?i).*[-_\.]jdk[0-9]+</ignoreVersion>
+  </ignoreVersions>
+  <rules>
+    <!-- Per-artifact pins go here as needed -->
+  </rules>
+</ruleset>

--- a/src/main/bin_distr_license_notices/LICENSE.txt
+++ b/src/main/bin_distr_license_notices/LICENSE.txt
@@ -243,7 +243,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This product contains SLF4J, licensed and distributed under the MIT license:
 
-Copyright (c) 2004-2017 QOS.ch
+Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
  All rights reserved.
 
  Permission is hereby granted, free  of charge, to any person obtaining

--- a/src/main/bin_distr_license_notices/NOTICE.md
+++ b/src/main/bin_distr_license_notices/NOTICE.md
@@ -17,14 +17,14 @@ ResolverUtil.java Copyright 2005-2006 Tim Fennell
 # Apache Commons IO
 
 Apache Commons IO
-Copyright 2002-2025 The Apache Software Foundation
+Copyright 2002-2026 The Apache Software Foundation
 
 # Apache Commons Lang
 
 Apache Commons Lang
 Copyright 2001-2025 The Apache Software Foundation
 
-# Jackson JSON processor NOTICE from the Jackson Jar 2.20.0
+# Jackson JSON processor NOTICE from the Jackson Jar 2.21.1
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
@@ -59,7 +59,7 @@ and the licenses and copyrights that apply to that code.
 
 # Spring Framework
 
-Copyright (c) 2002-2025 Pivotal, Inc.
+Copyright (c) 2002-2026 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/uimaj-parent-internal/pom.xml
+++ b/uimaj-parent-internal/pom.xml
@@ -55,31 +55,32 @@
     <execution.environment>JavaSE-21</execution.environment>
     
     <maven.version>3.8.1</maven.version>
+    <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
 
     <asciidoctor.plugin.version>3.2.0</asciidoctor.plugin.version>
     <asciidoctor.version>3.0.1</asciidoctor.version>
-    <asciidoctor.pdf.version>2.3.19</asciidoctor.pdf.version>
+    <asciidoctor.pdf.version>2.3.23</asciidoctor.pdf.version>
     <assertj-version>3.27.7</assertj-version>
     <bnd-version>7.3.0</bnd-version>
-    <bytebuddy-version>1.18.10</bytebuddy-version>
+    <bytebuddy-version>1.18.11</bytebuddy-version>
     <commons-csv-version>1.14.1</commons-csv-version>
     <commons-collections4-version>4.5.0</commons-collections4-version>
     <commons-io-version>2.22.0</commons-io-version>
     <commons-lang3-version>3.20.0</commons-lang3-version>
     <commons-math3-version>3.6.1</commons-math3-version>
     <jackson-version>2.21.1</jackson-version>
-    <javassist-version>3.31.0-GA</javassist-version>
+    <javassist-version>3.32.0-GA</javassist-version>
     <junit-version>5.14.3</junit-version>
-    <junit-platform-version>1.14.3</junit-platform-version>
+    <junit-platform-version>1.14.4</junit-platform-version>
     <junit-vintage-version>4.13.2</junit-vintage-version>
-    <log4j-version>2.25.3</log4j-version>
+    <log4j-version>2.26.1</log4j-version>
     <mockito-version>5.23.0</mockito-version>
     <opentest4j-version>1.3.0</opentest4j-version>
     <qdox-version>2.2.0</qdox-version>
-    <slf4j-version>2.0.17</slf4j-version>
+    <slf4j-version>2.0.18</slf4j-version>
     <spring-version>6.2.19</spring-version>
     <tycho-version>5.0.3</tycho-version>
-    <xmlunit-version>2.12.0</xmlunit-version>
+    <xmlunit-version>2.13.0</xmlunit-version>
 
     <eclipseP2RepoId>org.eclipse.p2.202306</eclipseP2RepoId>
 
@@ -274,17 +275,17 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.4.1</version>
+        <version>3.6.1</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
-        <version>4.8.0</version>
+        <version>4.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>
         <artifactId>maven-plugin-testing-harness</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -314,7 +315,7 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven.version}</version>
+        <version>${maven-plugin-tools.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
**What's in the PR**
- log4j 2.25.3 -> 2.26.1
- slf4j 2.0.17 -> 2.0.18
- bytebuddy 1.18.10 -> 1.18.11
- javassist 3.31.0-GA -> 3.32.0-GA
- xmlunit 2.12.0 -> 2.13.0
- junit-platform 1.14.3 -> 1.14.4
- asciidoctor-pdf 2.3.19 -> 2.3.23
- plexus-archiver 4.8.0 -> 4.12.0
- maven-plugin-testing-harness 3.3.0 -> 3.5.1
- maven-plugin-annotations 3.8.1 -> 3.15.2 (split from shared maven.version property)
- Add .mvn/versions-rules.xml to filter pre-release candidates in dependency upgrade discovery
- Decouple maven-plugin-tools version from Maven core API version to prevent property misalignment across artifact families
- Pin GitHub Actions to commit SHAs: actions/checkout v7.0.1, actions/setup-java v5.7.0, mikepenz/action-junit-report v6.4.2, github/codeql-action v4
- Remove stCarolas/setup-maven action and use runner-provided Maven 3.9.16 instead of installing 3.9.9

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [x] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
