### PR TITLE
Issue #462: Aggregate JavaDoc not provisioned for release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,8 @@
 
   <properties>
     <assemblyBinDescriptor>src/main/assembly/bin.xml</assemblyBinDescriptor>
-    <postNoticeText>${ibmNoticeText}</postNoticeText>    
+    <postNoticeText>${ibmNoticeText}</postNoticeText>
+    <aggregatedJavadocBaseDirectory>${project.build.directory}/site</aggregatedJavadocBaseDirectory>
   </properties>
 
   <modules>
@@ -312,6 +313,7 @@
                   </packages>
                 </group>
               </groups>
+              <outputDirectory>${aggregatedJavadocBaseDirectory}</outputDirectory>
               <doctitle>Apache UIMA Java SDK ${project.version} User-Level API Documentation</doctitle>
               <windowtitle>Apache UIMA Java SDK ${project.version} User-Level API Documentation</windowtitle>
             </configuration>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -261,7 +261,7 @@ under the License.
     </fileSet>
 
     <fileSet>
-      <directory>target/site/apidocs</directory>
+      <directory>${aggregatedJavadocBaseDirectory}/apidocs</directory>
       <outputDirectory>docs/d/api</outputDirectory>
       <excludes>
         <exclude>options</exclude>


### PR DESCRIPTION
**What's in the PR**
- Configure maven-javadoc-plugin to write aggregated javadoc to a shared property directory
- Update assembly descriptor to read aggregated javadoc from the configured property directory

**How to test manually**
* Check the release artifacts contain JavaDoc

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
